### PR TITLE
Fix AoE mechanics positions

### DIFF
--- a/backend/pkg/game/entities/ability.go
+++ b/backend/pkg/game/entities/ability.go
@@ -66,15 +66,15 @@ func (ability Ability) Mechanics() []Mechanic {
 }
 
 func (a *Ability) Clone() *Ability {
-	newAbility := *a // Start with a shallow copy
+	clone := *a // shallow copy of base fields
 
-	// Deep copy the mechanics slice
+	// Deep copy mechanics
 	if a.mechanics != nil {
-		newAbility.mechanics = make([]Mechanic, len(a.mechanics))
-		for i, mechanic := range a.mechanics {
-			newAbility.mechanics[i] = mechanic.Clone() // Use the deep copy method
+		clone.mechanics = make([]Mechanic, len(a.mechanics))
+		for i, mech := range a.mechanics {
+			clone.mechanics[i] = mech.Clone()
 		}
 	}
 
-	return &newAbility
+	return &clone
 }

--- a/backend/pkg/game/entities/mechanics.go
+++ b/backend/pkg/game/entities/mechanics.go
@@ -229,23 +229,32 @@ func resolveParameters(
 	}
 }
 
-func deepCopyMap(original map[string]interface{}) map[string]interface{} {
-	newMap := make(map[string]interface{}, len(original))
-	for k, v := range original {
-		// Handle nested maps
-		if nestedMap, ok := v.(map[string]interface{}); ok {
-			newMap[k] = deepCopyMap(nestedMap) // Recursively copy
-		} else {
-			newMap[k] = v // Copy other values as-is
-		}
-	}
-	return newMap
+func (m Mechanic) Clone() Mechanic {
+	cloned := m
+	cloned.Params = deepCloneParams(m.Params)
+	return cloned
 }
 
-func (m *Mechanic) Clone() Mechanic {
-	newMechanic := *m
-	if m.Params != nil {
-		newMechanic.Params = deepCopyMap(m.Params) // Use deep copy for maps
+func deepCloneParams(params map[string]interface{}) map[string]interface{} {
+	if params == nil {
+		return nil
 	}
-	return newMechanic
+	cloned := make(map[string]interface{}, len(params))
+	for k, v := range params {
+		switch val := v.(type) {
+		case []Mechanic:
+			// Clone []Mechanic recursively
+			newSlice := make([]Mechanic, len(val))
+			for i, mech := range val {
+				newSlice[i] = mech.Clone()
+			}
+			cloned[k] = newSlice
+		case map[string]interface{}:
+			// Recursively deep copy nested maps
+			cloned[k] = deepCloneParams(val)
+		default:
+			cloned[k] = val // Primitives and unhandled types
+		}
+	}
+	return cloned
 }


### PR DESCRIPTION
An issue arose when an AoE mechanic was executed after a targeted one, when this was cast once, all the subsequent casts would spawn the AoE on the position of the first cast, this was happening because when creating a cast ability character action, the ability wasn't being cloned correctly, causing all the mechanics parameters to actually be a pointer referencing the same parameters, so when one was edited setting the target coordinates, it actually was editing the base mechanic parameters, causing the rest to use this same value. Fixed by correcting the cloning methods of the mechanic type to handle slices of mechanics by copying them by value, which wasn't done before.