### PR TITLE
Deltas for whole game state messages

### DIFF
--- a/backend/api/dtos/dtos.go
+++ b/backend/api/dtos/dtos.go
@@ -60,11 +60,11 @@ func (p PositionDTO) GetType() string {
 }
 
 type ProjectileDTO struct {
-	Id       string      `json:"id"`
-	Caster   string      `json:"caster"`
-	Position PositionDTO `json:"position"`
-	Radius   float64     `json:"radius"`
-	State    string      `json:"state"`
+	Id       string       `json:"id"`
+	Caster   string       `json:"caster,omitempty"`
+	Position *PositionDTO `json:"position,omitempty"`
+	Radius   *float64     `json:"radius,omitempty"`
+	State    string       `json:"state,omitempty"`
 }
 
 func (p ProjectileDTO) GetType() string {

--- a/backend/api/dtos/dtos.go
+++ b/backend/api/dtos/dtos.go
@@ -23,14 +23,15 @@ func (g GameStateDTO) GetType() string {
 }
 
 type CharacterDTO struct {
-	Id              string             `json:"id"`
-	MaxHealth       int                `json:"maxHealth"`
-	CurrentHealth   int                `json:"currentHealth"`
-	Radius          float64            `json:"radius"`
-	Position        PositionDTO        `json:"position"`
-	ExecutingAction ExecutingActionDTO `json:"executingAction"`
-	Abilities       []AbilityDTO       `json:"abilities"`
-	Inventory       InventoryDTO       `json:"inventory"`
+	Id            string           `json:"id"`
+	MaxHealth     *int             `json:"maxHealth,omitempty"`
+	CurrentHealth *int             `json:"currentHealth,omitempty"`
+	Radius        *float64         `json:"radius,omitempty"`
+	Position      *PositionDTO     `json:"position,omitempty"`
+	Action        *entities.Action `json:"action,omitempty"`
+	Direction     *PositionDTO     `json:"direction,omitempty"`
+	Abilities     []AbilityDTO     `json:"abilities,omitempty"`
+	Inventory     InventoryDTO     `json:"inventory"` // Refactor this
 }
 
 func (p CharacterDTO) GetType() string {
@@ -78,11 +79,6 @@ type AoEDTO struct {
 
 func (AoEDTO) GetType() string {
 	return "AoE"
-}
-
-type ExecutingActionDTO struct {
-	Action    entities.Action `json:"action"`
-	Direction PositionDTO     `json:"direction"`
 }
 
 type InventoryDTO struct {

--- a/backend/api/dtos/dtos.go
+++ b/backend/api/dtos/dtos.go
@@ -12,11 +12,10 @@ type DTO interface {
 }
 
 type GameStateDTO struct {
-	Players           []CharacterDTO  `json:"players"`
-	Projectiles       []ProjectileDTO `json:"projectiles"`
-	AreaEffects       []AoEDTO        `json:"area_effects"`
-	Npcs              []CharacterDTO  `json:"npcs"`
-	EntitiesToDestroy []string        `json:"entities_to_destroy"`
+	Players     []CharacterDTO  `json:"players"`
+	Projectiles []ProjectileDTO `json:"projectiles"`
+	AreaEffects []AoEDTO        `json:"area_effects"`
+	Npcs        []CharacterDTO  `json:"npcs"`
 }
 
 func (g GameStateDTO) GetType() string {
@@ -72,10 +71,9 @@ func (p ProjectileDTO) GetType() string {
 }
 
 type AoEDTO struct {
-	Id       string      `json:"id"`
-	Caster   string      `json:"caster"`
-	Position PositionDTO `json:"position"`
-	Radius   float64     `json:"radius"`
+	Id       string       `json:"id"`
+	Position *PositionDTO `json:"position,omitempty"`
+	Radius   *float64     `json:"radius,omitempty"`
 }
 
 func (AoEDTO) GetType() string {

--- a/backend/api/dtos/dtos.go
+++ b/backend/api/dtos/dtos.go
@@ -31,7 +31,7 @@ type CharacterDTO struct {
 	Action        *entities.Action `json:"action,omitempty"`
 	Direction     *PositionDTO     `json:"direction,omitempty"`
 	Abilities     []AbilityDTO     `json:"abilities,omitempty"`
-	Inventory     InventoryDTO     `json:"inventory"` // Refactor this
+	Inventory     *InventoryDTO    `json:"inventory,omitempty"` // Refactor this
 }
 
 func (p CharacterDTO) GetType() string {
@@ -82,7 +82,12 @@ func (AoEDTO) GetType() string {
 }
 
 type InventoryDTO struct {
-	Items []entities.ItemChange `json:"items"`
+	Items []ItemDTO `json:"items,omitempty"`
+}
+
+type ItemDTO struct {
+	Id       string `json:"id"`
+	Quantity int64  `json:"quantity"`
 }
 
 type UseItemDTO struct {

--- a/backend/api/dtos/dtos.go
+++ b/backend/api/dtos/dtos.go
@@ -12,10 +12,10 @@ type DTO interface {
 }
 
 type GameStateDTO struct {
-	Players     []CharacterDTO  `json:"players"`
-	Projectiles []ProjectileDTO `json:"projectiles"`
-	AreaEffects []AoEDTO        `json:"area_effects"`
-	Npcs        []CharacterDTO  `json:"npcs"`
+	Players     []CharacterDTO  `json:"players,omitempty"`
+	Projectiles []ProjectileDTO `json:"projectiles,omitempty"`
+	AreaEffects []AoEDTO        `json:"area_effects,omitempty"`
+	Npcs        []CharacterDTO  `json:"npcs,omitempty"`
 }
 
 func (g GameStateDTO) GetType() string {

--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -36,7 +36,7 @@ func (m *Mapper) GameStateToDTO(gameState entities.GameState) *GameStateDTO {
 	}
 
 	for _, projectile := range gameState.GetProjectiles() {
-		projectileDTOS = append(projectileDTOS, *m.ProjectileToDTO(projectile))
+		projectileDTOS = append(projectileDTOS, *GetDiff(&projectile))
 	}
 
 	for _, npcs := range gameState.GetNPCs() {
@@ -65,7 +65,7 @@ func (m Mapper) AoEToDTO(AoE entities.AoE) AoEDTO {
 	return AoEDTO{
 		Id:       AoE.Id(),
 		Caster:   AoE.CasterId(),
-		Position: *m.PositionToDTO(AoE.Position()),
+		Position: *PositionToDTO(AoE.Position()),
 		Radius:   AoE.Radius(),
 	}
 }
@@ -101,7 +101,7 @@ func (m Mapper) PositionDTOToEntity(positionDTO PositionDTO) *utils.Vector2 {
 	return utils.NewVector2(positionDTO.X, positionDTO.Z)
 }
 
-func (m Mapper) PositionToDTO(position utils.Vector2) *PositionDTO {
+func PositionToDTO(position utils.Vector2) *PositionDTO {
 	x, z := position.GetPosition()
 	return &PositionDTO{
 		X: x,
@@ -122,14 +122,14 @@ func (m Mapper) CharacterToDTO(character entities.Character) *CharacterDTO {
 	executingActionDirection := characterExecutingAction.Direction()
 	executingActionDTO := ExecutingActionDTO{
 		Action:    characterExecutingAction.ActionType(),
-		Direction: *m.PositionToDTO(executingActionDirection),
+		Direction: *PositionToDTO(executingActionDirection),
 	}
 
 	characterInventory := InventoryDTO{Items: character.ChangeLogs()}
 
 	return &CharacterDTO{
 		Id:              character.GetId(),
-		Position:        *m.PositionToDTO(character.GetPosition()),
+		Position:        *PositionToDTO(character.GetPosition()),
 		Radius:          character.GetRadius(),
 		MaxHealth:       characterHealth.GetMaxHealth(),
 		CurrentHealth:   characterHealth.GetCurrentHealth(),
@@ -139,14 +139,26 @@ func (m Mapper) CharacterToDTO(character entities.Character) *CharacterDTO {
 	}
 }
 
-func (m Mapper) ProjectileToDTO(projectile entities.Projectile) *ProjectileDTO {
-	return &ProjectileDTO{
-		Id:       projectile.GetId(),
-		Caster:   projectile.CasterId(),
-		Position: *m.PositionToDTO(projectile.GetPosition()),
-		Radius:   projectile.GetRadius(),
-		State:    projectile.GetState(),
+func GetDiff(p *entities.Projectile) *ProjectileDTO {
+	diff := &ProjectileDTO{Id: p.GetId()}
+	if p.ProjectileLastSentState.Position == nil ||
+		!p.GetPosition().Equals(*p.ProjectileLastSentState.Position) {
+		diff.Position = PositionToDTO(p.GetPosition())
+		p.ProjectileLastSentState.Position = utils.NewVector2(p.GetPosition().GetPosition())
 	}
+	if p.ProjectileLastSentState.State == nil ||
+		p.State() != *p.ProjectileLastSentState.State {
+		diff.State = p.GetState()
+		state := p.State()
+		p.ProjectileLastSentState.State = &state
+	}
+	if p.ProjectileLastSentState.Radius == nil ||
+		p.GetRadius() != *p.ProjectileLastSentState.Radius {
+		radius := p.GetRadius()
+		diff.Radius = &radius
+		p.ProjectileLastSentState.Radius = &radius
+	}
+	return diff
 }
 
 func AbilityToDTO(ability entities.Ability) AbilityDTO {

--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -1,37 +1,18 @@
 package dtos
 
 import (
-	"sync"
-
 	"backend/pkg/game/entities"
 	"backend/pkg/utils"
 )
 
-type Mapper struct {
-	entitiesIds []string
-}
-
-var mapperInstance *Mapper
-var doItOnce sync.Once
-
-func GetMapper() *Mapper {
-	doItOnce.Do(func() {
-		mapperInstance = &Mapper{
-			entitiesIds: make([]string, 0),
-		}
-	})
-
-	return mapperInstance
-}
-
-func (m *Mapper) GameStateToDTO(gameState entities.GameState) *GameStateDTO {
+func GameStateDiff(gameState entities.GameState) GameStateDTO {
 	playerDTOS := make([]CharacterDTO, 0)
 	projectileDTOS := make([]ProjectileDTO, 0)
 	npcsDTOS := make([]CharacterDTO, 0)
 	AoEDTOS := make([]AoEDTO, 0)
 
 	for _, player := range gameState.GetPlayers() {
-		playerDTOS = append(playerDTOS, *m.CharacterToDTO(player))
+		playerDTOS = append(playerDTOS, *GetCharacterDiff(&player))
 	}
 
 	for _, projectile := range gameState.GetProjectiles() {
@@ -39,15 +20,14 @@ func (m *Mapper) GameStateToDTO(gameState entities.GameState) *GameStateDTO {
 	}
 
 	for _, npcs := range gameState.GetNPCs() {
-		npcsDTOS = append(npcsDTOS, *m.CharacterToDTO(*npcs.Character))
+		npcsDTOS = append(npcsDTOS, *GetCharacterDiff(npcs.Character))
 	}
 
-	areaEffects := gameState.AreaEffects()
-	for _, AoE := range areaEffects {
+	for _, AoE := range gameState.AreaEffects() {
 		AoEDTOS = append(AoEDTOS, *GetAoEDiff(AoE))
 	}
 
-	return &GameStateDTO{
+	return GameStateDTO{
 		Players:     playerDTOS,
 		Projectiles: projectileDTOS,
 		Npcs:        npcsDTOS,
@@ -55,23 +35,7 @@ func (m *Mapper) GameStateToDTO(gameState entities.GameState) *GameStateDTO {
 	}
 }
 
-func GetAoEDiff(AoE *entities.AoE) *AoEDTO {
-	diff := &AoEDTO{Id: AoE.Id()}
-	if AoE.AoELastTickState.Position == nil ||
-		!AoE.Position().Equals(*AoE.AoELastTickState.Position) {
-		diff.Position = PositionToDTO(AoE.Position())
-		AoE.AoELastTickState.Position = utils.NewVector2(AoE.Position().GetPosition())
-	}
-	if AoE.AoELastTickState.Radius == nil ||
-		AoE.Radius() != *AoE.AoELastTickState.Radius {
-		radius := AoE.Radius()
-		diff.Radius = &radius
-		AoE.AoELastTickState.Radius = &radius
-	}
-	return diff
-}
-
-func (m Mapper) PositionDTOToEntity(positionDTO PositionDTO) *utils.Vector2 {
+func PositionDTOToEntity(positionDTO PositionDTO) *utils.Vector2 {
 	return utils.NewVector2(positionDTO.X, positionDTO.Z)
 }
 
@@ -83,7 +47,7 @@ func PositionToDTO(position utils.Vector2) *PositionDTO {
 	}
 }
 
-func (m Mapper) CharacterToDTO(character entities.Character) *CharacterDTO {
+func CharacterToDTO(character entities.Character) CharacterDTO {
 	characterHealth := character.GetHealth()
 	characterAbilities := make([]AbilityDTO, 0)
 	for _, ability := range character.GetAbilities() {
@@ -92,25 +56,88 @@ func (m Mapper) CharacterToDTO(character entities.Character) *CharacterDTO {
 		characterAbilities = append(characterAbilities, abilityDTO)
 	}
 
+	currentHealth := characterHealth.GetCurrentHealth()
+	maxHealth := characterHealth.GetMaxHealth()
+	radius := character.GetRadius()
 	characterExecutingAction := character.GetExecutingAction()
 	executingActionDirection := characterExecutingAction.Direction()
-	executingActionDTO := ExecutingActionDTO{
-		Action:    characterExecutingAction.ActionType(),
-		Direction: *PositionToDTO(executingActionDirection),
-	}
+	actionType := characterExecutingAction.ActionType()
+	characterInventory := InventoryDTO{Items: character.GetInventory()}
 
-	characterInventory := InventoryDTO{Items: character.ChangeLogs()}
-
-	return &CharacterDTO{
-		Id:              character.GetId(),
-		Position:        *PositionToDTO(character.GetPosition()),
-		Radius:          character.GetRadius(),
-		MaxHealth:       characterHealth.GetMaxHealth(),
-		CurrentHealth:   characterHealth.GetCurrentHealth(),
-		ExecutingAction: executingActionDTO,
-		Abilities:       characterAbilities,
-		Inventory:       characterInventory,
+	return CharacterDTO{
+		Id:            character.GetId(),
+		Position:      PositionToDTO(character.GetPosition()),
+		Radius:        &radius,
+		MaxHealth:     &maxHealth,
+		CurrentHealth: &currentHealth,
+		Action:        &actionType,
+		Direction:     PositionToDTO(executingActionDirection),
+		Abilities:     characterAbilities,
+		Inventory:     characterInventory,
 	}
+}
+
+func AbilityToDTO(ability entities.Ability) AbilityDTO {
+	return AbilityDTO{
+		Id:       ability.Id(),
+		Name:     ability.Name(),
+		Range:    ability.Range(),
+		Cooldown: ability.Cooldown(),
+	}
+}
+
+func GetCharacterDiff(c *entities.Character) *CharacterDTO {
+	diff := &CharacterDTO{Id: c.GetId()}
+	if c.CharacterLastTickState.Position == nil ||
+		!c.GetPosition().Equals(*c.CharacterLastTickState.Position) {
+		diff.Position = PositionToDTO(c.GetPosition())
+		c.CharacterLastTickState.Position = utils.NewVector2(c.GetPosition().GetPosition())
+	}
+	if c.CharacterLastTickState.Radius == nil ||
+		c.GetRadius() != *c.CharacterLastTickState.Radius {
+		radius := c.GetRadius()
+		diff.Radius = &radius
+		c.CharacterLastTickState.Radius = &radius
+	}
+	if c.CharacterLastTickState.MaxHealth == nil ||
+		c.GetMaxHealth() != *c.CharacterLastTickState.MaxHealth {
+		maxHealth := c.GetMaxHealth()
+		diff.MaxHealth = &maxHealth
+		c.CharacterLastTickState.MaxHealth = &maxHealth
+	}
+	if c.CharacterLastTickState.CurrentHealth == nil ||
+		c.GetCurrentHealth() != *c.CharacterLastTickState.CurrentHealth {
+		currentHealth := c.GetCurrentHealth()
+		diff.CurrentHealth = &currentHealth
+		c.CharacterLastTickState.CurrentHealth = &currentHealth
+	}
+	if c.CharacterLastTickState.Action == nil ||
+		c.GetExecutingAction().
+			ActionType() !=
+			*c.CharacterLastTickState.Action {
+		action := c.GetExecutingAction().ActionType()
+		diff.Action = &action
+		c.CharacterLastTickState.Action = &action
+	}
+	if c.CharacterLastTickState.Direction == nil ||
+		c.GetExecutingAction().
+			Direction().Equals(*c.CharacterLastTickState.Direction) {
+		diff.Direction = PositionToDTO(c.GetExecutingAction().Direction())
+		c.CharacterLastTickState.Direction = utils.NewVector2(
+			c.GetExecutingAction().Direction().GetPosition(),
+		)
+	}
+	// move this into a function and do diff check
+	characterAbilities := make([]AbilityDTO, 0)
+	for _, ability := range c.GetAbilities() {
+		abilityDTO := AbilityToDTO(*ability)
+		abilityDTO.RemainingCooldown = float64(c.RemainingCooldown(ability)) / 1000
+		characterAbilities = append(characterAbilities, abilityDTO)
+	}
+	diff.Abilities = characterAbilities
+	characterInventory := InventoryDTO{Items: c.ChangeLogs()}
+	diff.Inventory = characterInventory
+	return diff
 }
 
 func GetProjectileDiff(p *entities.Projectile) *ProjectileDTO {
@@ -135,11 +162,71 @@ func GetProjectileDiff(p *entities.Projectile) *ProjectileDTO {
 	return diff
 }
 
-func AbilityToDTO(ability entities.Ability) AbilityDTO {
-	return AbilityDTO{
-		Id:       ability.Id(),
-		Name:     ability.Name(),
-		Range:    ability.Range(),
-		Cooldown: ability.Cooldown(),
+func GetAoEDiff(AoE *entities.AoE) *AoEDTO {
+	diff := &AoEDTO{Id: AoE.Id()}
+	if AoE.AoELastTickState.Position == nil ||
+		!AoE.Position().Equals(*AoE.AoELastTickState.Position) {
+		diff.Position = PositionToDTO(AoE.Position())
+		AoE.AoELastTickState.Position = utils.NewVector2(AoE.Position().GetPosition())
 	}
+	if AoE.AoELastTickState.Radius == nil ||
+		AoE.Radius() != *AoE.AoELastTickState.Radius {
+		radius := AoE.Radius()
+		diff.Radius = &radius
+		AoE.AoELastTickState.Radius = &radius
+	}
+	return diff
+}
+
+func GameStateToDTO(gameState entities.GameState) *GameStateDTO {
+	playerDTOS := make([]CharacterDTO, 0)
+	projectileDTOS := make([]ProjectileDTO, 0)
+	npcsDTOS := make([]CharacterDTO, 0)
+	AoEDTOS := make([]AoEDTO, 0)
+
+	for _, player := range gameState.GetPlayers() {
+		playerDTOS = append(playerDTOS, CharacterToDTO(player))
+	}
+
+	for _, projectile := range gameState.GetProjectiles() {
+		projectileDTOS = append(projectileDTOS, ProjectileTODTO(projectile))
+	}
+
+	for _, npcs := range gameState.GetNPCs() {
+		npcsDTOS = append(npcsDTOS, CharacterToDTO(*npcs.Character))
+	}
+
+	areaEffects := gameState.AreaEffects()
+	for _, AoE := range areaEffects {
+		AoEDTOS = append(AoEDTOS, AoEToDTO(AoE))
+	}
+
+	return &GameStateDTO{
+		Players:     playerDTOS,
+		Projectiles: projectileDTOS,
+		Npcs:        npcsDTOS,
+		AreaEffects: AoEDTOS,
+	}
+}
+
+func ProjectileTODTO(p entities.Projectile) ProjectileDTO {
+	radius := p.GetRadius()
+	projectile := ProjectileDTO{
+		Id:       p.GetId(),
+		Caster:   p.CasterId(),
+		Position: PositionToDTO(p.GetPosition()),
+		Radius:   &radius,
+		State:    p.GetState(),
+	}
+	return projectile
+}
+
+func AoEToDTO(AoE *entities.AoE) AoEDTO {
+	radius := AoE.Radius()
+	AoEDTO := AoEDTO{
+		Id:       AoE.Id(),
+		Position: PositionToDTO(AoE.Position()),
+		Radius:   &radius,
+	}
+	return AoEDTO
 }

--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -1,7 +1,6 @@
 package dtos
 
 import (
-	"slices"
 	"sync"
 
 	"backend/pkg/game/entities"
@@ -36,7 +35,7 @@ func (m *Mapper) GameStateToDTO(gameState entities.GameState) *GameStateDTO {
 	}
 
 	for _, projectile := range gameState.GetProjectiles() {
-		projectileDTOS = append(projectileDTOS, *GetDiff(&projectile))
+		projectileDTOS = append(projectileDTOS, *GetProjectileDiff(&projectile))
 	}
 
 	for _, npcs := range gameState.GetNPCs() {
@@ -44,57 +43,32 @@ func (m *Mapper) GameStateToDTO(gameState entities.GameState) *GameStateDTO {
 	}
 
 	areaEffects := gameState.AreaEffects()
-	for AoEId, areaEffect := range areaEffects {
-		if !slices.Contains(m.entitiesIds, AoEId) {
-			AoEDTOS = append(AoEDTOS, m.AoEToDTO(*areaEffect))
-			m.entitiesIds = append(m.entitiesIds, AoEId)
-		}
+	for _, AoE := range areaEffects {
+		AoEDTOS = append(AoEDTOS, *GetAoEDiff(AoE))
 	}
-	destroyedAoEs := m.GetDestroyedAoEs(areaEffects)
 
 	return &GameStateDTO{
-		Players:           playerDTOS,
-		Projectiles:       projectileDTOS,
-		Npcs:              npcsDTOS,
-		AreaEffects:       AoEDTOS,
-		EntitiesToDestroy: destroyedAoEs,
+		Players:     playerDTOS,
+		Projectiles: projectileDTOS,
+		Npcs:        npcsDTOS,
+		AreaEffects: AoEDTOS,
 	}
 }
 
-func (m Mapper) AoEToDTO(AoE entities.AoE) AoEDTO {
-	return AoEDTO{
-		Id:       AoE.Id(),
-		Caster:   AoE.CasterId(),
-		Position: *PositionToDTO(AoE.Position()),
-		Radius:   AoE.Radius(),
+func GetAoEDiff(AoE *entities.AoE) *AoEDTO {
+	diff := &AoEDTO{Id: AoE.Id()}
+	if AoE.AoELastTickState.Position == nil ||
+		!AoE.Position().Equals(*AoE.AoELastTickState.Position) {
+		diff.Position = PositionToDTO(AoE.Position())
+		AoE.AoELastTickState.Position = utils.NewVector2(AoE.Position().GetPosition())
 	}
-}
-
-func (m *Mapper) GetDestroyedAoEs(areaEffects map[string]*entities.AoE) []string {
-	destroyedAoEs := []string{}
-
-	for _, id := range m.entitiesIds {
-		if _, exists := areaEffects[id]; !exists {
-			destroyedAoEs = append(destroyedAoEs, id)
-		}
+	if AoE.AoELastTickState.Radius == nil ||
+		AoE.Radius() != *AoE.AoELastTickState.Radius {
+		radius := AoE.Radius()
+		diff.Radius = &radius
+		AoE.AoELastTickState.Radius = &radius
 	}
-
-	// Remove destroyed IDs from m.entitiesIds
-	m.entitiesIds = filter(m.entitiesIds, func(id string) bool {
-		return areaEffects[id] != nil
-	})
-
-	return destroyedAoEs
-}
-
-func filter(ids []string, predicate func(string) bool) []string {
-	var result []string
-	for _, id := range ids {
-		if predicate(id) {
-			result = append(result, id)
-		}
-	}
-	return result
+	return diff
 }
 
 func (m Mapper) PositionDTOToEntity(positionDTO PositionDTO) *utils.Vector2 {
@@ -139,24 +113,24 @@ func (m Mapper) CharacterToDTO(character entities.Character) *CharacterDTO {
 	}
 }
 
-func GetDiff(p *entities.Projectile) *ProjectileDTO {
+func GetProjectileDiff(p *entities.Projectile) *ProjectileDTO {
 	diff := &ProjectileDTO{Id: p.GetId()}
-	if p.ProjectileLastSentState.Position == nil ||
-		!p.GetPosition().Equals(*p.ProjectileLastSentState.Position) {
+	if p.ProjectileLastTickState.Position == nil ||
+		!p.GetPosition().Equals(*p.ProjectileLastTickState.Position) {
 		diff.Position = PositionToDTO(p.GetPosition())
-		p.ProjectileLastSentState.Position = utils.NewVector2(p.GetPosition().GetPosition())
+		p.ProjectileLastTickState.Position = utils.NewVector2(p.GetPosition().GetPosition())
 	}
-	if p.ProjectileLastSentState.State == nil ||
-		p.State() != *p.ProjectileLastSentState.State {
+	if p.ProjectileLastTickState.State == nil ||
+		p.State() != *p.ProjectileLastTickState.State {
 		diff.State = p.GetState()
 		state := p.State()
-		p.ProjectileLastSentState.State = &state
+		p.ProjectileLastTickState.State = &state
 	}
-	if p.ProjectileLastSentState.Radius == nil ||
-		p.GetRadius() != *p.ProjectileLastSentState.Radius {
+	if p.ProjectileLastTickState.Radius == nil ||
+		p.GetRadius() != *p.ProjectileLastTickState.Radius {
 		radius := p.GetRadius()
 		diff.Radius = &radius
-		p.ProjectileLastSentState.Radius = &radius
+		p.ProjectileLastTickState.Radius = &radius
 	}
 	return diff
 }

--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -64,7 +64,14 @@ func CharacterToDTO(character entities.Character) CharacterDTO {
 	characterExecutingAction := character.GetExecutingAction()
 	executingActionDirection := characterExecutingAction.Direction()
 	actionType := characterExecutingAction.ActionType()
-	characterInventory := InventoryDTO{Items: character.GetInventory()}
+
+	characterInventory := InventoryDTO{}
+	for item, quantity := range character.GetInventory() {
+		characterInventory.Items = append(
+			characterInventory.Items,
+			ItemDTO{Id: item, Quantity: quantity},
+		)
+	}
 
 	return CharacterDTO{
 		Id:            character.GetId(),
@@ -75,7 +82,7 @@ func CharacterToDTO(character entities.Character) CharacterDTO {
 		Action:        &actionType,
 		Direction:     PositionToDTO(executingActionDirection),
 		Abilities:     characterAbilities,
-		Inventory:     characterInventory,
+		Inventory:     &characterInventory,
 	}
 }
 
@@ -128,13 +135,12 @@ func GetCharacterDiff(c *entities.Character) *CharacterDTO {
 			c.GetExecutingAction().Direction().GetPosition(),
 		)
 	}
-	diff.Abilities = GetAbilitiesDiff(c)
-	characterInventory := InventoryDTO{Items: c.ChangeLogs()}
-	diff.Inventory = characterInventory
+	diff.Abilities = getAbilitiesDiff(c)
+	diff.Inventory = getInventoryDiff(c)
 	return diff
 }
 
-func GetAbilitiesDiff(c *entities.Character) []AbilityDTO {
+func getAbilitiesDiff(c *entities.Character) []AbilityDTO {
 	abilitiesDTOs := make([]AbilityDTO, 0)
 	characterAbilities := c.GetAbilities()
 
@@ -158,6 +164,55 @@ func GetAbilitiesDiff(c *entities.Character) []AbilityDTO {
 	}
 
 	return abilitiesDTOs
+}
+
+func getInventoryDiff(c *entities.Character) *InventoryDTO {
+	inventoryDTO := InventoryDTO{}
+	characterInventory := c.GetInventory()
+	itemIds := lo.Map(lo.Keys(characterInventory), func(id string, _ int) string {
+		return id
+	})
+
+	newItemsIds, removedItemsIds := lo.Difference(
+		itemIds,
+		lo.Keys(c.CharacterLastTickState.Items),
+	)
+
+	if len(newItemsIds) > 0 || len(removedItemsIds) > 0 {
+		for itemId, quantity := range characterInventory {
+			inventoryDTO.Items = append(
+				inventoryDTO.Items,
+				ItemDTO{Id: itemId, Quantity: quantity},
+			)
+		}
+		c.CharacterLastTickState.Items = lo.Associate(
+			inventoryDTO.Items,
+			func(i ItemDTO) (string, int64) {
+				return i.Id, i.Quantity
+			},
+		)
+		for _, itemId := range removedItemsIds {
+			inventoryDTO.Items = append(inventoryDTO.Items, ItemDTO{Id: itemId, Quantity: 0})
+		}
+		return &inventoryDTO
+	} else {
+		for itemId, quantity := range characterInventory {
+			if quantity != c.CharacterLastTickState.Items[itemId] {
+				inventoryDTO.Items = append(inventoryDTO.Items, ItemDTO{Id: itemId, Quantity: quantity})
+			}
+		}
+		if len(inventoryDTO.Items) > 0 {
+			c.CharacterLastTickState.Items = lo.Associate(
+				inventoryDTO.Items,
+				func(i ItemDTO) (string, int64) {
+					return i.Id, i.Quantity
+				},
+			)
+			return &inventoryDTO
+		}
+	}
+
+	return nil
 }
 
 func buildAbilityDTO(

--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -3,6 +3,8 @@ package dtos
 import (
 	"backend/pkg/game/entities"
 	"backend/pkg/utils"
+
+	"github.com/samber/lo"
 )
 
 func GameStateDiff(gameState entities.GameState) GameStateDTO {
@@ -126,17 +128,48 @@ func GetCharacterDiff(c *entities.Character) *CharacterDTO {
 			c.GetExecutingAction().Direction().GetPosition(),
 		)
 	}
-	// move this into a function and do diff check
-	characterAbilities := make([]AbilityDTO, 0)
-	for _, ability := range c.GetAbilities() {
-		abilityDTO := AbilityToDTO(*ability)
-		abilityDTO.RemainingCooldown = float64(c.RemainingCooldown(ability)) / 1000
-		characterAbilities = append(characterAbilities, abilityDTO)
-	}
-	diff.Abilities = characterAbilities
+	diff.Abilities = GetAbilitiesDiff(c)
 	characterInventory := InventoryDTO{Items: c.ChangeLogs()}
 	diff.Inventory = characterInventory
 	return diff
+}
+
+func GetAbilitiesDiff(c *entities.Character) []AbilityDTO {
+	abilitiesDTOs := make([]AbilityDTO, 0)
+	characterAbilities := c.GetAbilities()
+
+	newAbilityIds, _ := lo.Difference(
+		lo.Keys(characterAbilities),
+		c.CharacterLastTickState.Abilities,
+	)
+
+	if len(newAbilityIds) > 0 {
+		for abilityId, ability := range characterAbilities {
+			abilitiesDTOs = append(abilitiesDTOs, buildAbilityDTO(c, abilityId, ability))
+		}
+		c.CharacterLastTickState.Abilities = lo.Keys(characterAbilities)
+	} else {
+		for abilityId, ability := range characterAbilities {
+			remainingCooldown := c.RemainingCooldown(ability)
+			if remainingCooldown != c.CharacterLastTickState.AbilitiesRemainingCooldows[abilityId] {
+				abilitiesDTOs = append(abilitiesDTOs, buildAbilityDTO(c, abilityId, ability))
+			}
+		}
+	}
+
+	return abilitiesDTOs
+}
+
+func buildAbilityDTO(
+	c *entities.Character,
+	abilityId string,
+	ability *entities.Ability,
+) AbilityDTO {
+	remainingCooldown := c.RemainingCooldown(ability)
+	abilityDTO := AbilityToDTO(*ability)
+	abilityDTO.RemainingCooldown = float64(remainingCooldown) / 1000
+	c.CharacterLastTickState.AbilitiesRemainingCooldows[abilityId] = remainingCooldown
+	return abilityDTO
 }
 
 func GetProjectileDiff(p *entities.Projectile) *ProjectileDTO {

--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -120,8 +120,7 @@ func GetCharacterDiff(c *entities.Character) *CharacterDTO {
 		c.CharacterLastTickState.Action = &action
 	}
 	if c.CharacterLastTickState.Direction == nil ||
-		c.GetExecutingAction().
-			Direction().Equals(*c.CharacterLastTickState.Direction) {
+		!c.GetExecutingAction().Direction().Equals(*c.CharacterLastTickState.Direction) {
 		diff.Direction = PositionToDTO(c.GetExecutingAction().Direction())
 		c.CharacterLastTickState.Direction = utils.NewVector2(
 			c.GetExecutingAction().Direction().GetPosition(),

--- a/backend/connection/native_server.go
+++ b/backend/connection/native_server.go
@@ -52,13 +52,23 @@ func (server *NativeServer) readLoop() {
 		case client := <-server.addClient:
 			player := gameplay.AddPlayer(server.gameState, client)
 			server.clients[client] = true
-			response := CreateWebSocketResponse(*dtos.GetMapper().CharacterToDTO(player))
+
+			response := CreateWebSocketResponse(dtos.CharacterToDTO(player))
 			message := response.Serialize()
 			err := websocket.Message.Send(client, message)
 			if err != nil {
 				log.Println("Error broadcasting message:", err)
 				return
 			}
+
+			// Send initial gamestate to client
+			gameStateDTO := dtos.GameStateToDTO(*server.gameState)
+			webSocketResponse := CreateWebSocketResponse(gameStateDTO)
+			if err := websocket.Message.Send(client, webSocketResponse.Serialize()); err != nil {
+				log.Println("Error broadcasting initial message:", err)
+				return
+			}
+
 			log.Println("Client connected", client.RemoteAddr())
 		case client := <-server.removeClient:
 			server.gameState.DeletePlayer(client)
@@ -89,7 +99,7 @@ func (server *NativeServer) broadcastGameState() {
 		previousUpdateTime = currentUpdateTime
 		gameplay.UpdateState(server.gameState, deltaTime.Seconds())
 
-		gameStateDTO := *dtos.GetMapper().GameStateToDTO(*server.gameState)
+		gameStateDTO := dtos.GameStateDiff(*server.gameState)
 		webSocketResponse := CreateWebSocketResponse(gameStateDTO)
 		server.broadcast <- webSocketResponse.Serialize()
 	}
@@ -134,7 +144,7 @@ func (server *NativeServer) handlePlayerMovement(
 	client *websocket.Conn,
 	positionDTO dtos.PositionDTO,
 ) {
-	position := *dtos.GetMapper().PositionDTOToEntity(positionDTO)
+	position := *dtos.PositionDTOToEntity(positionDTO)
 
 	// this should be just one "action", one line of code, it gives access to two different things while the entry point should be single
 	player := server.gameState.GetPlayerByConn(client)
@@ -186,7 +196,7 @@ func (server *NativeServer) handleRespawn(client *websocket.Conn) {
 		player.HealthVariation(player.GetMaxHealth())
 		player.MoveTowards(*utils.NewVector2(0, 0))
 		player.SetPosition(*utils.NewVector2(0, 0))
-		response := CreateWebSocketResponse(*dtos.GetMapper().CharacterToDTO(*player))
+		response := CreateWebSocketResponse(dtos.CharacterToDTO(*player))
 		response.ActionType = "respawn"
 		message := response.Serialize()
 		websocket.Message.Send(client, message)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/samber/lo v1.50.0
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.16.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -49,6 +49,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/samber/lo v1.50.0 h1:XrG0xOeHs+4FQ8gJR97zDz5uOFMW7OwFWiFVzqopKgY=
+github.com/samber/lo v1.50.0/go.mod h1:RjZyNk6WSnUFRKK6EyOhsRJMqft3G+pg7dCWHQCWvsc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/backend/pkg/game/entities/AoE.go
+++ b/backend/pkg/game/entities/AoE.go
@@ -7,6 +7,11 @@ import (
 	"github.com/google/uuid"
 )
 
+type AoELastTickState struct {
+	Position *utils.Vector2
+	Radius   *float64
+}
+
 type AoE struct {
 	id                  string
 	caster              string
@@ -15,6 +20,8 @@ type AoE struct {
 	remainingDurationMs int
 	onHitMechanics      []Mechanic
 	hitCharacterIds     []string
+
+	AoELastTickState *AoELastTickState
 }
 
 func InstantiateAoE(
@@ -31,6 +38,7 @@ func InstantiateAoE(
 		radius:              radius,
 		remainingDurationMs: durationMs,
 		onHitMechanics:      onHitMechanics,
+		AoELastTickState:    &AoELastTickState{},
 	}
 }
 

--- a/backend/pkg/game/entities/character.go
+++ b/backend/pkg/game/entities/character.go
@@ -35,14 +35,14 @@ func (action ExecutingAction) Direction() utils.Vector2 {
 }
 
 type CharacterLastTickState struct {
-	Position          *utils.Vector2
-	Radius            *float64
-	MaxHealth         *int
-	CurrentHealth     *int
-	Action            *Action
-	Direction         *utils.Vector2
-	Abilities         []string
-	AbilitiesLastUsed map[string]time.Time
+	Position                   *utils.Vector2
+	Radius                     *float64
+	MaxHealth                  *int
+	CurrentHealth              *int
+	Action                     *Action
+	Direction                  *utils.Vector2
+	Abilities                  []string
+	AbilitiesRemainingCooldows map[string]int64
 }
 
 type Character struct {
@@ -74,16 +74,18 @@ func CreateCharacter(id string, x, z float64, abilities map[string]*Ability) *Ch
 	}
 
 	return &Character{
-		id:                     id,
-		position:               initialPosition,
-		to:                     initialPosition,
-		Health:                 stats.NewHealth(BASE_MAX_HEALTH),
-		executingAction:        ExecutingAction{Idle, *utils.NewVector2(0, 0)},
-		actionsQueue:           []CharacterAction{},
-		Inventory:              NewInventory(),
-		abilities:              abilities,
-		lastUsed:               lastUsed,
-		CharacterLastTickState: &CharacterLastTickState{},
+		id:              id,
+		position:        initialPosition,
+		to:              initialPosition,
+		Health:          stats.NewHealth(BASE_MAX_HEALTH),
+		executingAction: ExecutingAction{Idle, *utils.NewVector2(0, 0)},
+		actionsQueue:    []CharacterAction{},
+		Inventory:       NewInventory(),
+		abilities:       abilities,
+		lastUsed:        lastUsed,
+		CharacterLastTickState: &CharacterLastTickState{
+			AbilitiesRemainingCooldows: make(map[string]int64),
+		},
 	}
 }
 

--- a/backend/pkg/game/entities/character.go
+++ b/backend/pkg/game/entities/character.go
@@ -34,6 +34,17 @@ func (action ExecutingAction) Direction() utils.Vector2 {
 	return action.direction
 }
 
+type CharacterLastTickState struct {
+	Position          *utils.Vector2
+	Radius            *float64
+	MaxHealth         *int
+	CurrentHealth     *int
+	Action            *Action
+	Direction         *utils.Vector2
+	Abilities         []string
+	AbilitiesLastUsed map[string]time.Time
+}
+
 type Character struct {
 	id string
 	stats.Health
@@ -44,6 +55,8 @@ type Character struct {
 	actionsQueue    []CharacterAction
 
 	*Inventory
+
+	CharacterLastTickState *CharacterLastTickState
 
 	// should this be here?
 	abilities map[string]*Ability
@@ -61,15 +74,16 @@ func CreateCharacter(id string, x, z float64, abilities map[string]*Ability) *Ch
 	}
 
 	return &Character{
-		id:              id,
-		position:        initialPosition,
-		to:              initialPosition,
-		Health:          stats.NewHealth(BASE_MAX_HEALTH),
-		executingAction: ExecutingAction{Idle, *utils.NewVector2(0, 0)},
-		actionsQueue:    []CharacterAction{},
-		Inventory:       NewInventory(),
-		abilities:       abilities,
-		lastUsed:        lastUsed,
+		id:                     id,
+		position:               initialPosition,
+		to:                     initialPosition,
+		Health:                 stats.NewHealth(BASE_MAX_HEALTH),
+		executingAction:        ExecutingAction{Idle, *utils.NewVector2(0, 0)},
+		actionsQueue:           []CharacterAction{},
+		Inventory:              NewInventory(),
+		abilities:              abilities,
+		lastUsed:               lastUsed,
+		CharacterLastTickState: &CharacterLastTickState{},
 	}
 }
 

--- a/backend/pkg/game/entities/character.go
+++ b/backend/pkg/game/entities/character.go
@@ -43,6 +43,7 @@ type CharacterLastTickState struct {
 	Direction                  *utils.Vector2
 	Abilities                  []string
 	AbilitiesRemainingCooldows map[string]int64
+	Items                      map[string]int64
 }
 
 type Character struct {
@@ -85,6 +86,7 @@ func CreateCharacter(id string, x, z float64, abilities map[string]*Ability) *Ch
 		lastUsed:        lastUsed,
 		CharacterLastTickState: &CharacterLastTickState{
 			AbilitiesRemainingCooldows: make(map[string]int64),
+			Items:                      make(map[string]int64),
 		},
 	}
 }
@@ -252,9 +254,9 @@ func (character *Character) UseItem(itemId string, targetId string, gs *GameStat
 		return
 	}
 
-	item := character.GetItem(itemId)
+	item := existingItems[itemId]
 	item.ExecuteMechanics(character, targetId, gs)
-	character.Inventory.AddItem(item, -1)
+	character.Inventory.AddItem(itemId, -1)
 }
 
 func (caster *Character) EnqueueAbilityCastAction(

--- a/backend/pkg/game/entities/character_action.go
+++ b/backend/pkg/game/entities/character_action.go
@@ -18,8 +18,10 @@ type MoveAction struct {
 
 func (a *MoveAction) Execute(character *Character, _ *GameState) error {
 	if !a.isComplete {
-		character.MoveTowards(a.TargetPosition)
-		a.isComplete = character.position == a.TargetPosition // Adjust this check based on your movement logic
+		if character.to != a.TargetPosition { // This isn't a good check see https://github.com/tkz00/MMORPG/issues/38
+			character.MoveTowards(a.TargetPosition)
+		}
+		a.isComplete = character.position == a.TargetPosition
 	}
 	return nil
 }

--- a/backend/pkg/game/entities/inventory.go
+++ b/backend/pkg/game/entities/inventory.go
@@ -1,89 +1,75 @@
 // I don't know if this should be in entities, prolly doesn't matter, same for item
 package entities
 
-import "fmt"
-
-type ItemChange struct {
-	Id       string `json:"id"`       // Template ID of the item
-	Quantity int    `json:"quantity"` // New quantity of the item
-}
+import (
+	"fmt"
+)
 
 type Inventory struct {
-	items     map[*Item]int
-	changeLog []ItemChange
+	items map[string]int64
 }
 
 func NewInventory() *Inventory {
 	return &Inventory{
-		items: make(map[*Item]int),
+		items: make(map[string]int64),
 	}
 }
 
 func (looter *Inventory) Loot(loot *Inventory) {
-	for item := range loot.items {
-		looter.AddItem(item, loot.items[item])
+	for item, qty := range loot.items {
+		looter.AddItem(item, qty)
+		looter.PrintInventory()
 	}
 }
 
-func (looter *Inventory) AddItem(item *Item, quantity int) {
-	for itemInInventory := range looter.items {
-		if itemInInventory.id == item.id {
-			looter.items[item] += quantity
-			if looter.items[item] == 0 {
-				delete(looter.items, item)
+func (looter *Inventory) AddItem(itemId string, quantity int64) {
+	for itemInInventoryId := range looter.items {
+		if itemInInventoryId == itemId {
+			looter.items[itemId] += quantity
+			if looter.items[itemId] == 0 {
+				delete(looter.items, itemId)
 			}
-			looter.changeLog = append(looter.changeLog, ItemChange{
-				Id:       item.id,
-				Quantity: quantity,
-			})
 			return
 		}
 	}
 
-	looter.items[item] = quantity
-	looter.changeLog = append(looter.changeLog, ItemChange{
-		Id:       item.id,
-		Quantity: quantity,
-	})
+	looter.items[itemId] = quantity
 }
 
 func (inv Inventory) CanConsume(itemId string) bool {
-	for item := range inv.items {
-		if item.id == itemId {
-			return item.isConsumable
+	for itemInInventoryId := range inv.items {
+		if itemInInventoryId == itemId {
+			return GetItem(itemId).isConsumable
 		}
 	}
 	return false
 }
 
-func (inv Inventory) GetItem(itemId string) *Item {
-	for item := range inv.items {
-		if item.id == itemId {
-			return item
-		}
-	}
-	return nil
+func GetItem(itemId string) *Item {
+	return existingItems[itemId]
 }
 
-func (inventory *Inventory) ChangeLogs() []ItemChange {
-	changes := inventory.changeLog
-	inventory.changeLog = []ItemChange{}
-	return changes
-}
-
-func (inventory *Inventory) GetInventory() []ItemChange {
-	invSlice := []ItemChange{}
-	for item, qty := range inventory.items {
-		invSlice = append(invSlice, ItemChange{Id: item.id, Quantity: qty})
-	}
-	return invSlice
+func (inv Inventory) GetInventory() map[string]int64 {
+	return inv.items
 }
 
 func (inv *Inventory) PrintInventory() {
 	if len(inv.items) > 0 {
-		for item, quantity := range inv.items {
-			fmt.Printf("%s, %d - ", item.name, quantity)
+		for itemId, quantity := range inv.items {
+			fmt.Printf("%s, %d - ", itemId, quantity)
 		}
 		fmt.Print("\n")
 	}
+}
+
+var existingItems = map[string]*Item{
+	"0": NewItem(
+		"0",
+		"small health potion",
+		Mechanic{
+			MechanicType: "heal",
+			Params:       map[string]interface{}{"amount": 40.0},
+		},
+	),
+	"1": NewItem("1", "leather"),
 }

--- a/backend/pkg/game/entities/inventory.go
+++ b/backend/pkg/game/entities/inventory.go
@@ -47,12 +47,6 @@ func (looter *Inventory) AddItem(item *Item, quantity int) {
 	})
 }
 
-func (inventory *Inventory) ChangeLogs() []ItemChange {
-	changes := inventory.changeLog
-	inventory.changeLog = []ItemChange{}
-	return changes
-}
-
 func (inv Inventory) CanConsume(itemId string) bool {
 	for item := range inv.items {
 		if item.id == itemId {
@@ -69,6 +63,20 @@ func (inv Inventory) GetItem(itemId string) *Item {
 		}
 	}
 	return nil
+}
+
+func (inventory *Inventory) ChangeLogs() []ItemChange {
+	changes := inventory.changeLog
+	inventory.changeLog = []ItemChange{}
+	return changes
+}
+
+func (inventory *Inventory) GetInventory() []ItemChange {
+	invSlice := []ItemChange{}
+	for item, qty := range inventory.items {
+		invSlice = append(invSlice, ItemChange{Id: item.id, Quantity: qty})
+	}
+	return invSlice
 }
 
 func (inv *Inventory) PrintInventory() {

--- a/backend/pkg/game/entities/projectile.go
+++ b/backend/pkg/game/entities/projectile.go
@@ -24,6 +24,8 @@ type Projectile struct {
 	to             utils.Vector2
 	state          ProjectileState
 	onHitMechanics []Mechanic
+
+	ProjectileLastSentState *ProjectileLastTickState
 }
 
 func CreateProjectile(
@@ -38,13 +40,14 @@ func CreateProjectile(
 	direction := normalizedVector.Scale(PROJECTILE_SPEED)
 
 	return &Projectile{
-		id:             uuid.New().String(),
-		caster:         caster,
-		direction:      direction,
-		position:       initialPosition,
-		to:             to,
-		state:          Active,
-		onHitMechanics: onHitMechanics,
+		id:                      uuid.New().String(),
+		caster:                  caster,
+		direction:               direction,
+		position:                initialPosition,
+		to:                      to,
+		state:                   Active,
+		onHitMechanics:          onHitMechanics,
+		ProjectileLastSentState: &ProjectileLastTickState{Position: nil, State: nil},
 	}
 }
 
@@ -106,4 +109,10 @@ func (projectile Projectile) Hit(target *Character, gs *GameState) {
 		}
 	}
 	resolveMechanics(projectile.caster, gs, projectile.onHitMechanics)
+}
+
+type ProjectileLastTickState struct {
+	Position *utils.Vector2
+	State    *ProjectileState
+	Radius   *float64
 }

--- a/backend/pkg/game/entities/projectile.go
+++ b/backend/pkg/game/entities/projectile.go
@@ -16,6 +16,12 @@ const (
 	Hit
 )
 
+type ProjectileLastTickState struct {
+	Position *utils.Vector2
+	State    *ProjectileState
+	Radius   *float64
+}
+
 type Projectile struct {
 	id             string
 	caster         string
@@ -25,7 +31,7 @@ type Projectile struct {
 	state          ProjectileState
 	onHitMechanics []Mechanic
 
-	ProjectileLastSentState *ProjectileLastTickState
+	ProjectileLastTickState *ProjectileLastTickState
 }
 
 func CreateProjectile(
@@ -47,7 +53,7 @@ func CreateProjectile(
 		to:                      to,
 		state:                   Active,
 		onHitMechanics:          onHitMechanics,
-		ProjectileLastSentState: &ProjectileLastTickState{Position: nil, State: nil},
+		ProjectileLastTickState: &ProjectileLastTickState{},
 	}
 }
 
@@ -109,10 +115,4 @@ func (projectile Projectile) Hit(target *Character, gs *GameState) {
 		}
 	}
 	resolveMechanics(projectile.caster, gs, projectile.onHitMechanics)
-}
-
-type ProjectileLastTickState struct {
-	Position *utils.Vector2
-	State    *ProjectileState
-	Radius   *float64
 }

--- a/backend/pkg/game/entities/spawner.go
+++ b/backend/pkg/game/entities/spawner.go
@@ -59,16 +59,9 @@ func (spawner *Spawner) GetNewNPCs() []*Npc {
 			spawner.HandleNPCDeath(npcs[i])
 		})
 		if rand.IntN(2) == 0 {
-			npcs[i].AddItem(
-				NewItem(
-					"1",
-					"small health potion",
-					Mechanic{MechanicType: "heal", Params: map[string]interface{}{"amount": 40.0}},
-				),
-				1,
-			)
+			npcs[i].AddItem("0", 1)
 		} else {
-			npcs[i].AddItem(NewItem("2", "leather"), 2)
+			npcs[i].AddItem("1", 2)
 		}
 	}
 

--- a/client/Assets/ScriptableObjects/Items/Leather.asset
+++ b/client/Assets/ScriptableObjects/Items/Leather.asset
@@ -12,5 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c683e6446fa44c0989dc9141e303d8e, type: 3}
   m_Name: Leather
   m_EditorClassIdentifier: 
-  id: 2
+  id: 1
   icon: {fileID: 21300000, guid: fe17bcef71ea81e4cbc4ede9743ec01f, type: 3}
+  isConsumible: 0

--- a/client/Assets/ScriptableObjects/Items/Small Health Potion.asset
+++ b/client/Assets/ScriptableObjects/Items/Small Health Potion.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c683e6446fa44c0989dc9141e303d8e, type: 3}
   m_Name: Small Health Potion
   m_EditorClassIdentifier: 
-  id: 1
+  id: 0
   icon: {fileID: 21300000, guid: 4e8b35477a7fb5a46870c1973a523722, type: 3}
   isConsumible: 1

--- a/client/Assets/Scripts/Dtos/CharacterDTO.cs
+++ b/client/Assets/Scripts/Dtos/CharacterDTO.cs
@@ -5,18 +5,13 @@ public class CharacterDTO : DTO
 {
     public string id;
     public PositionDTO position;
-    public float radius;
-    public int maxHealth;
-    public int currentHealth;
-    public ExecutingAction executingAction;
+    public float? radius;
+    public int? maxHealth;
+    public int? currentHealth;
+    public CharacterAction? action;
+    public PositionDTO direction;
     public AbilityDTO[] abilities;
     public InventoryDTO inventory;
-}
-
-public class ExecutingAction
-{
-    public CharacterAction action;
-    public PositionDTO direction;
 }
 
 public enum CharacterAction

--- a/client/Assets/Scripts/Dtos/ProjectileDTO.cs
+++ b/client/Assets/Scripts/Dtos/ProjectileDTO.cs
@@ -7,7 +7,7 @@ public class ProjectileDTO : DTO
     public string id;
     public string caster;
     public PositionDTO position;
-    public float radius;
+    public float? radius = null;
 
     [JsonProperty("state")]
     [JsonConverter(typeof(StringEnumConverter))]

--- a/client/Assets/Scripts/GameManager.cs
+++ b/client/Assets/Scripts/GameManager.cs
@@ -87,7 +87,7 @@ public class GameManager : MonoBehaviour
         UpdatePlayers(gameState.players);
         UpdateProjectiles(gameState.projectiles);
         UpdateNPCs(gameState.npcs);
-        UpdateAreaEffects(gameState);
+        UpdateAreaEffects(gameState.aoEs);
 
         CharacterDTO mainPlayer = gameState.players.Find(player => player.id == mainPlayerID);
 
@@ -96,9 +96,15 @@ public class GameManager : MonoBehaviour
         inventory.UpdateInventory(mainPlayer.inventory);
     }
 
-    private void UpdateAreaEffects(GameStateDTO gameState)
+    private void UpdateAreaEffects(List<AreaEffectDTO> AoEs)
     {
-        foreach (AreaEffectDTO areaEffectDTO in gameState.aoEs)
+        string[] currentAoEsIds = areaEffects.Keys.ToArray();
+        HashSet<string> AoEsToDestroy = new HashSet<string>(
+            currentAoEsIds.Except(AoEs.Select(AoE => AoE.id))
+        );
+        DestroyAoEs(AoEsToDestroy.ToArray());
+
+        foreach (AreaEffectDTO areaEffectDTO in AoEs)
         {
             bool areaEffectExists = areaEffects.Any(aoe => aoe.Key == areaEffectDTO.id);
             if (!areaEffectExists)
@@ -113,12 +119,14 @@ public class GameManager : MonoBehaviour
                 areaEffects[areaEffectDTO.id].transform.localScale = Vector3.one * (areaEffectDTO.radius * 2);
             }
         }
+    }
 
-        // Destroy old AoEs
-        foreach (string entitiesToDestroy in gameState.entitiesToDestroy)
+    void DestroyAoEs(string[] AoEsToDestroy)
+    {
+        foreach (string AoEId in AoEsToDestroy)
         {
-            Destroy(areaEffects[entitiesToDestroy].gameObject);
-            areaEffects.Remove(entitiesToDestroy);
+            Destroy(areaEffects[AoEId].gameObject);
+            areaEffects.Remove(AoEId);
         }
     }
 

--- a/client/Assets/Scripts/GameManager.cs
+++ b/client/Assets/Scripts/GameManager.cs
@@ -98,6 +98,11 @@ public class GameManager : MonoBehaviour
 
     private void UpdateAreaEffects(List<AreaEffectDTO> AoEs)
     {
+        if (AoEs == null || AoEs.Count == 0)
+        {
+            DestroyAoEs(areaEffects.Keys.ToArray());
+            return;
+        }
         string[] currentAoEsIds = areaEffects.Keys.ToArray();
         HashSet<string> AoEsToDestroy = new HashSet<string>(
             currentAoEsIds.Except(AoEs.Select(AoE => AoE.id))
@@ -246,6 +251,11 @@ public class GameManager : MonoBehaviour
 
     private void UpdateProjectiles(List<ProjectileDTO> projectilesDTOS)
     {
+        if (projectilesDTOS == null || projectilesDTOS.Count == 0)
+        {
+            DestroyProjectiles(projectiles.Keys.ToArray());
+            return;
+        }
         string[] currentProjectileIds = projectiles.Keys.ToArray();
         HashSet<string> projectilesToDestroy = new HashSet<string>(
             currentProjectileIds.Except(projectilesDTOS.Select(projectile => projectile.id))
@@ -300,6 +310,11 @@ public class GameManager : MonoBehaviour
 
     private void UpdateNPCs(List<CharacterDTO> npcsDTOS)
     {
+        if (npcsDTOS == null || npcsDTOS.Count == 0)
+        {
+            DestroyNPCs(npcs.Keys.ToArray());
+            return;
+        }
         string[] currentNPCsIds = npcs.Keys.ToArray();
         HashSet<string> npcsToDestroy = new HashSet<string>(
             currentNPCsIds.Except(npcsDTOS.Select(npc => npc.id))

--- a/client/Assets/Scripts/GameManager.cs
+++ b/client/Assets/Scripts/GameManager.cs
@@ -255,9 +255,10 @@ public class GameManager : MonoBehaviour
             bool projectileExists = projectiles.Any(p => p.Key == projectile.id);
             if (projectileExists)
             {
-                projectiles[projectile.id].Move(
-                    new Vector3(projectile.position.x, 0, projectile.position.z)
-                );
+                if (projectile.position != null)
+                    projectiles[projectile.id].Move(
+                        new Vector3(projectile.position.x, 0, projectile.position.z)
+                    );
             }
             else
             {
@@ -269,12 +270,12 @@ public class GameManager : MonoBehaviour
                 projectiles[projectile.id] = newProjectileGO.GetComponent<Projectile>();
                 newProjectileGO.GetComponent<MeshRenderer>().material.color = Color.blue;
             }
-            projectiles[projectile.id].SetScale(projectile.radius * 2);
+
+            if (projectile.radius != null)
+                projectiles[projectile.id].SetScale((float)(projectile.radius * 2));
 
             if (projectile.state == State.Hit)
-            {
                 projectiles[projectile.id].TriggerHit();
-            }
         }
     }
 

--- a/client/Assets/Scripts/GameManager.cs
+++ b/client/Assets/Scripts/GameManager.cs
@@ -90,9 +90,7 @@ public class GameManager : MonoBehaviour
         UpdateAreaEffects(gameState.aoEs);
 
         CharacterDTO mainPlayer = gameState.players.Find(player => player.id == mainPlayerID);
-
         abilitiesPanel.UpdatePlayerPanel(mainPlayer);
-
         inventory.UpdateInventory(mainPlayer.inventory);
     }
 

--- a/client/Assets/Scripts/GameManager.cs
+++ b/client/Assets/Scripts/GameManager.cs
@@ -152,11 +152,11 @@ public class GameManager : MonoBehaviour
                 player = GetPlayer(playerDTO.id);
             else
                 player = CreatePlayer(playerDTO);
-            player.Movement.Move(new Vector3(playerDTO.position.x, 0, playerDTO.position.z));
+            if (playerDTO.position != null) player.Movement.Move(new Vector3(playerDTO.position.x, 0, playerDTO.position.z));
             player.UpdateHealth(playerDTO.currentHealth, playerDTO.maxHealth);
             UpdateCharacterAnimations(playerDTO, player);
 
-            player.SetScale(playerDTO.radius * 2);
+            if (playerDTO.radius != null) player.SetScale((float)(playerDTO.radius * 2));
 
             CheckDeathSplash(playerDTO);
         }
@@ -180,17 +180,15 @@ public class GameManager : MonoBehaviour
 
     private void UpdateCharacterAnimations(CharacterDTO characterDTO, Character character)
     {
-        if (characterDTO.currentHealth > 0)
+        if (character.Stats.CurrentHealth > 0)
         {
-            character.HandleActionFeedback(characterDTO.executingAction);
-
+            if (characterDTO.action != null) character.HandleActionFeedback((CharacterAction)characterDTO.action);
+            if (characterDTO.direction != null) character.Movement.RotateTowards(characterDTO.direction);
             return;
         }
 
         if (character.IsAlive)
-        {
             character.TriggerDeath();
-        }
     }
 
     private Character CreatePlayer(CharacterDTO playerDTO)
@@ -319,7 +317,7 @@ public class GameManager : MonoBehaviour
             if (npcExists)
             {
                 npc = npcs[npcDTO.id];
-                npc.Movement.Move(new Vector3(npcDTO.position.x, 0, npcDTO.position.z));
+                if (npcDTO.position != null) npc.Movement.Move(new Vector3(npcDTO.position.x, 0, npcDTO.position.z));
             }
             else
             {
@@ -327,9 +325,10 @@ public class GameManager : MonoBehaviour
             }
             npc.UpdateHealth(npcDTO.currentHealth, npcDTO.maxHealth);
 
-            npc.HandleActionFeedback(npcDTO.executingAction);
+            if (npcDTO.action != null) npc.HandleActionFeedback((CharacterAction)npcDTO.action);
+            if (npcDTO.direction != null) npc.Movement.RotateTowards(npcDTO.direction);
 
-            npc.SetScale(npcDTO.radius * 2);
+            if (npcDTO.radius != null) npc.SetScale((float)(npcDTO.radius * 2));
         }
     }
 

--- a/client/Assets/Scripts/Models/Character.cs
+++ b/client/Assets/Scripts/Models/Character.cs
@@ -46,16 +46,16 @@ public class Character : MonoBehaviour, ITargeteable
         playerNameUI.text = playerName;
     }
 
-    public void UpdateHealth(int currentHealth, int maxHealth)
+    public void UpdateHealth(int? currentHealth, int? maxHealth)
     {
         // this logic should be changed, "states" should come from the backend and them trigger specific feedbacks, i.e.: the "healed" state should trigger the respective healing vfx
-        if (this.Stats.CurrentHealth < currentHealth)
+        if (currentHealth != null && this.Stats.CurrentHealth < currentHealth)
         {
             this.playerVFXsHandler.TriggerHealingVFX();
         }
 
-        this.Stats.UpdateHealth(currentHealth, maxHealth);
-        this.healthBar.UpdateHealthBar(currentHealth, maxHealth);
+        this.stats.UpdateHealth(currentHealth, maxHealth);
+        this.healthBar.UpdateHealthBar(this.stats.CurrentHealth, this.stats.MaxHealth);
     }
 
     public string GetTargetId()
@@ -101,23 +101,20 @@ public class Character : MonoBehaviour, ITargeteable
         playerNameUI.transform.parent.gameObject.SetActive(false);
     }
 
-    public void HandleActionFeedback(ExecutingAction action)
+    public void HandleActionFeedback(CharacterAction action)
     {
-        switch (action.action)
+        switch (action)
         {
             case CharacterAction.Attacking:
                 Movement.TriggerWalkingAnimation(false);
                 Movement.AttackAnimation();
-                Movement.RotateTowards(action.direction);
                 break;
             case CharacterAction.CastingHeal:
                 Movement.TriggerWalkingAnimation(false);
                 Movement.HealAnimation();
-                Movement.RotateTowards(action.direction);
                 break;
             case CharacterAction.Moving:
                 Movement.TriggerWalkingAnimation(true);
-                Movement.RotateTowards(action.direction);
                 break;
             default:
                 Movement.TriggerWalkingAnimation(false);

--- a/client/Assets/Scripts/Models/PlayerStats.cs
+++ b/client/Assets/Scripts/Models/PlayerStats.cs
@@ -6,9 +6,9 @@ public class PlayerStats
     public int MaxHealth { private set; get; }
     public int CurrentHealth { private set; get; }
 
-    public void UpdateHealth(int currentHealth, int maxHealth)
+    public void UpdateHealth(int? currentHealth, int? maxHealth)
     {
-        this.CurrentHealth = currentHealth;
-        this.MaxHealth = maxHealth;
+        this.CurrentHealth = (int)(currentHealth != null ? currentHealth : this.CurrentHealth);
+        this.MaxHealth = (int)(maxHealth != null ? maxHealth : this.MaxHealth);
     }
 }

--- a/client/Assets/Scripts/Services/WebSocketConnection.cs
+++ b/client/Assets/Scripts/Services/WebSocketConnection.cs
@@ -90,7 +90,6 @@ public static class WebSocketConnection
 
                 if (_responseHandlers.ContainsKey(response.ActionType))
                 {
-                    Debug.Log(responseJson);
                     var handler = _responseHandlers[response.ActionType];
                     handler.DynamicInvoke(response.Body);
                 }

--- a/client/Assets/Scripts/Services/WebSocketConnection.cs
+++ b/client/Assets/Scripts/Services/WebSocketConnection.cs
@@ -90,6 +90,7 @@ public static class WebSocketConnection
 
                 if (_responseHandlers.ContainsKey(response.ActionType))
                 {
+                    Debug.Log(responseJson);
                     var handler = _responseHandlers[response.ActionType];
                     handler.DynamicInvoke(response.Body);
                 }

--- a/client/Assets/Scripts/UI/AbilitiesPanel.cs
+++ b/client/Assets/Scripts/UI/AbilitiesPanel.cs
@@ -87,6 +87,9 @@ public class AbilitiesPanel : MonoBehaviour
 
     public void UpdatePlayerPanel(CharacterDTO playerDTO)
     {
+        if (playerDTO.abilities == null)
+            return;
+
         foreach (AbilityDTO abilityDTO in playerDTO.abilities)
         {
             if (abilityIcons[abilityDTO.id] != null)

--- a/client/Assets/Scripts/UI/Inventory.cs
+++ b/client/Assets/Scripts/UI/Inventory.cs
@@ -43,17 +43,9 @@ public class Inventory : MonoBehaviour
         if (inventory.items.Length == 0)
             return;
 
-        var itemVariations = inventory.items.Select(item => (item.id, item.quantity));
-        foreach ((string id, int quantity) in itemVariations)
+        foreach ((string id, int quantity) in inventory.items.Select(item => (item.id, item.quantity)))
         {
-            if (items.ContainsKey(id))
-            {
-                items[id] += quantity;
-            }
-            else
-            {
-                items[id] = quantity;
-            }
+            items[id] = quantity;
 
             if (items[id] == 0)
             {


### PR DESCRIPTION
Managed to implement deltas for projectiles and AoEs, but found an issue when working with the characters (players and NPCs), although this is present for all entities. If a game is running, and a player connects, in the first update, it will receive only the diffs between the current state of the already existing entities and their previous tick state, which causes the game to break, since some required information will be missing, for example, if a character hasn't moved in the last tick, the player that enters the game then, will not receive any position data for that character, causing the game to break, the solution is to send the whole game state, not just deltas, when a player first connects to the game.

Also I need to think about how to send and register diffs of abilities and their cooldowns.

- [x] Made most fields in messages between backend and client optional.
- [x] The backend now sends an initial state when a client connects, for it to have a initial point from where to apply the diffs to.
- [x] Player can move and cast abilities, the NPC responds correctly.
- [x]  Rotations don't work, the direction field is always sent as `0, 0`.
- [x] Abilities are still sent every update.
- [x] Do we want to send empty arrays? Rn most updates projectiles and AoEs arrays are empty, should we not send them at all? Yes, now empty arrays aren't sent, but when players, npcs, projectiles or area effects exist in the game, when they've had no state change, their ids are still sent, this is to know they're still there, if we didn't do this then the client won't know which entities cease to exist, we'd have to send a "destroyed" collection of some type.
- [x] The inventory probably isn't updated correctly.