### PR TITLE
Add separate IsComplete check for character actions

### DIFF
--- a/backend/pkg/game/entities/character.go
+++ b/backend/pkg/game/entities/character.go
@@ -159,19 +159,16 @@ func (c *Character) ExecuteNextAction(gs *GameState) {
 		return
 	}
 
-	// this logic should be different, bc now every action is executed on each update, this has no effect on the
-	// behavior of the system (at least for now) but it could be confusing. Maybe a way to fix is to have the
-	// queue and a single executingAction field of type character action, when the last executingAction is
-	// completed (IsComplete()), the next action in the queue is moved to this single field and it's Execute
-	// function called, probably can be done with just the queue and changing some of the logic
 	currentAction := c.actionsQueue[0]
-	err := currentAction.Execute(c, gs)
-	if err != nil {
-		fmt.Println("Error executing action:", err)
-		return
+	if !currentAction.IsExecuted() {
+		err := currentAction.Execute(c, gs)
+		if err != nil {
+			fmt.Println("Error executing action:", err)
+			return
+		}
 	}
 
-	if currentAction.IsComplete() {
+	if currentAction.IsComplete(c) {
 		c.actionsQueue = c.actionsQueue[1:]
 	}
 }

--- a/backend/pkg/game/entities/character_action.go
+++ b/backend/pkg/game/entities/character_action.go
@@ -9,35 +9,38 @@ import (
 
 type CharacterAction interface {
 	Execute(player *Character, gs *GameState) error
-	IsComplete() bool
+	IsComplete(character *Character) bool
+	IsExecuted() bool
 }
 
 type MoveAction struct {
 	TargetPosition utils.Vector2
-	isComplete     bool
+	isExecuted     bool
 }
 
 func (a *MoveAction) Execute(
 	character *Character,
 	_ *GameState,
 ) error {
-	if !a.isComplete {
-		if character.to != a.TargetPosition { // This isn't a good check see https://github.com/tkz00/MMORPG/issues/38
-			character.MoveTowards(a.TargetPosition)
-		}
-		a.isComplete = character.position == a.TargetPosition
+	if character.to != a.TargetPosition {
+		character.MoveTowards(a.TargetPosition)
 	}
+	a.isExecuted = true
 	return nil
 }
 
-func (a *MoveAction) IsComplete() bool {
-	return a.isComplete
+func (a *MoveAction) IsComplete(character *Character) bool {
+	return a.isExecuted && a.TargetPosition.Equals(character.position)
+}
+
+func (a *MoveAction) IsExecuted() bool {
+	return a.isExecuted
 }
 
 type AbilityCastAction struct {
 	ability        Ability
 	castParameters map[Targeting]interface{}
-	isComplete     bool
+	isExecuted     bool
 }
 
 func (action *AbilityCastAction) Execute(
@@ -64,7 +67,6 @@ func (action *AbilityCastAction) Execute(
 					fmt.Println(err)
 				} else {
 					caster.lastUsed[action.ability.id] = time.Now()
-					action.isComplete = true
 
 					actionDurationInTicks := action.ability.executionDurationMs / config.TICKER_TIME.Milliseconds()
 					durationPtr := new(int64)
@@ -108,7 +110,6 @@ func (action *AbilityCastAction) Execute(
 					fmt.Println(err)
 				} else {
 					caster.lastUsed[action.ability.id] = time.Now()
-					action.isComplete = true
 
 					actionDurationInTicks := action.ability.executionDurationMs / config.TICKER_TIME.Milliseconds()
 					durationPtr := new(int64)
@@ -126,11 +127,16 @@ func (action *AbilityCastAction) Execute(
 			}
 		}
 	}
+	action.isExecuted = true
 	return nil
 }
 
-func (action *AbilityCastAction) IsComplete() bool {
-	return action.isComplete
+func (action *AbilityCastAction) IsComplete(character *Character) bool {
+	return action.isExecuted
+}
+
+func (action *AbilityCastAction) IsExecuted() bool {
+	return action.isExecuted
 }
 
 func MoveIfNotInRange(


### PR DESCRIPTION
Closes #38 

## Changes
- Modified the `CharacterAction` interface to better handle action execution and completion states, these where separated while before we had only completeness
- Updated `MoveAction` and `AbilityCastAction` to properly track their execution state
- Fixed `MoveAction.IsComplete()` to correctly check character position against target position instead of just returning a flag state
- Simplified `AbilityCastAction.IsComplete()` to return based on execution state. This wouldn't make sense for a move action since the execution of that action is just setting the destination of the character, while the completion is for the character to be positioned in the destination, but for ability casts the completion and execution do match.

## Technical Details
- Actions now track their execution state internally through the `isExecuted` flag
- The `isExecuted` flag is set only within the `Execute` method of each action
- `MoveAction` completion is determined by checking if the character has reached the target position
- `AbilityCastAction` completion is determined by whether the action has been executed
- Removed redundant `isComplete` boolean fields in favor of proper completion checks

## Impact
- Actions are now executed only once, rather than on every tick
- Movement actions properly track when a character reaches their destination
- Ability cast actions complete immediately after execution
- The action queue system now correctly prevents actions from being executed multiple times