### PR TITLE
Fix equipment bugs

### DIFF
--- a/backend/api/dtos/mapper.go
+++ b/backend/api/dtos/mapper.go
@@ -142,81 +142,117 @@ func getAbilitiesDiff(c *entities.Character) []AbilityDTO {
 	return abilitiesDTOs
 }
 
+// getInventoryDiff compares the current character inventory against the last tick
+// and returns an InventoryDTO diff if any relevant changes are detected.
 func getInventoryDiff(c *entities.Character) *InventoryDTO {
-	inventoryDTO := InventoryDTO{}
-	characterInventory := c.GetInventory()
-	itemIds := lo.Map(lo.Keys(characterInventory), func(id string, _ int) string {
-		return id
-	})
+	currentInventory := c.GetInventory()
 
-	newItemsIds, removedItemsIds := lo.Difference(
-		itemIds,
+	if len(lo.Keys(currentInventory)) == 0 {
+		return nil
+	}
+
+	currentlyEquipped := getEquippedMap(c)
+
+	newItemIDs, removedItemIDs := lo.Difference(
+		lo.Keys(currentInventory),
 		lo.Keys(c.CharacterLastTickState.Items),
 	)
 
-	// Track current equipped items
-	currentEquipped := make(map[string]bool)
-	for _, equip := range c.GetEquipped() {
-		currentEquipped[equip.Id()] = true
-	}
-
-	// Check for equipment changes
-	equipmentChanged := false
-	for itemId := range characterInventory {
-		if currentEquipped[itemId] != c.CharacterLastTickState.EquippedItems[itemId] {
-			equipmentChanged = true
-			break
-		}
-	}
-
-	if len(newItemsIds) > 0 || len(removedItemsIds) > 0 || equipmentChanged {
-		for itemId, quantity := range characterInventory {
-			inventoryDTO.Items = append(
-				inventoryDTO.Items,
-				ItemDTO{
-					Id:         itemId,
-					Quantity:   quantity,
-					IsEquipped: currentEquipped[itemId],
-				},
-			)
-		}
-		c.CharacterLastTickState.Items = lo.Associate(
-			inventoryDTO.Items,
-			func(i ItemDTO) (string, int64) {
-				return i.Id, i.Quantity
-			},
-		)
-		c.CharacterLastTickState.EquippedItems = currentEquipped
-		for _, itemId := range removedItemsIds {
-			inventoryDTO.Items = append(
-				inventoryDTO.Items,
-				ItemDTO{Id: itemId, Quantity: 0, IsEquipped: false},
-			)
-		}
-		return &inventoryDTO
+	inventoryDTO := &InventoryDTO{}
+	if len(newItemIDs) > 0 || len(removedItemIDs) > 0 || hasEquipmentChanged(c, currentlyEquipped) {
+		inventoryDTO = buildFullInventoryDiff(c, currentInventory, currentlyEquipped, removedItemIDs)
 	} else {
-		for itemId, quantity := range characterInventory {
-			if quantity != c.CharacterLastTickState.Items[itemId] || currentEquipped[itemId] != c.CharacterLastTickState.EquippedItems[itemId] {
-				inventoryDTO.Items = append(inventoryDTO.Items, ItemDTO{
-					Id:         itemId,
-					Quantity:   quantity,
-					IsEquipped: currentEquipped[itemId],
-				})
-			}
+		inventoryDTO = buildIncrementalInventoryDiff(c, currentlyEquipped)
+	}
+
+	return inventoryDTO
+}
+
+// getEquippedMap returns a map of equipped item IDs for fast lookup.
+func getEquippedMap(c *entities.Character) map[string]bool {
+	m := make(map[string]bool, len(c.GetEquipped()))
+	for _, equip := range c.GetEquipped() {
+		m[equip.Id()] = true
+	}
+	return m
+}
+
+// hasEquipmentChanged checks if the equipped items differ from the last tick state.
+func hasEquipmentChanged(c *entities.Character, currentlyEquipped map[string]bool) bool {
+	for itemID := range c.GetInventory() {
+		if currentlyEquipped[itemID] != c.CharacterLastTickState.EquippedItems[itemID] {
+			return true
 		}
-		if len(inventoryDTO.Items) > 0 {
-			c.CharacterLastTickState.Items = lo.Associate(
-				inventoryDTO.Items,
-				func(i ItemDTO) (string, int64) {
-					return i.Id, i.Quantity
-				},
-			)
-			c.CharacterLastTickState.EquippedItems = currentEquipped
-			return &inventoryDTO
+	}
+	return false
+}
+
+// buildFullInventoryDiff rebuilds the entire inventory state when items were added,
+// removed, or equipment changed.
+func buildFullInventoryDiff(
+	c *entities.Character,
+	currentInventory map[string]int64,
+	currentlyEquipped map[string]bool,
+	removedItemIDs []string,
+) *InventoryDTO {
+	dto := &InventoryDTO{}
+
+	// Add all current items
+	for itemID, quantity := range currentInventory {
+		dto.Items = append(dto.Items, ItemDTO{
+			Id:         itemID,
+			Quantity:   quantity,
+			IsEquipped: currentlyEquipped[itemID],
+		})
+	}
+
+	// Update last tick state
+	c.CharacterLastTickState.Items = lo.Associate(dto.Items, func(i ItemDTO) (string, int64) {
+		return i.Id, i.Quantity
+	})
+	c.CharacterLastTickState.EquippedItems = currentlyEquipped
+
+	// Add removed items (with quantity 0)
+	for _, itemID := range removedItemIDs {
+		dto.Items = append(dto.Items, ItemDTO{
+			Id:         itemID,
+			Quantity:   0,
+			IsEquipped: false,
+		})
+	}
+
+	return dto
+}
+
+// buildIncrementalInventoryDiff adds only items whose quantity has changed.
+// Equipment changes are excluded here, since they’re caught earlier.
+func buildIncrementalInventoryDiff(
+	c *entities.Character,
+	currentlyEquipped map[string]bool,
+) *InventoryDTO {
+	dto := &InventoryDTO{}
+
+	for itemID, quantity := range c.GetInventory() {
+		if quantity != c.CharacterLastTickState.Items[itemID] {
+			dto.Items = append(dto.Items, ItemDTO{
+				Id:         itemID,
+				Quantity:   quantity,
+				IsEquipped: currentlyEquipped[itemID],
+			})
 		}
 	}
 
-	return nil
+	if len(dto.Items) == 0 {
+		return nil
+	}
+
+	// Update last tick state
+	c.CharacterLastTickState.Items = lo.Associate(dto.Items, func(i ItemDTO) (string, int64) {
+		return i.Id, i.Quantity
+	})
+	c.CharacterLastTickState.EquippedItems = currentlyEquipped
+
+	return dto
 }
 
 func getStatsDiff(c *entities.Character) *map[string]int64 {
@@ -335,10 +371,13 @@ func CharacterToDTO(character entities.Character) CharacterDTO {
 	characterStats := character.GetStats()
 
 	characterInventory := InventoryDTO{}
+	equipped := lo.Map(lo.Values(character.GetEquipped()), func(item *entities.Equipment, index int) string {
+		return item.Id()
+	})
 	for item, quantity := range character.GetInventory() {
 		characterInventory.Items = append(
 			characterInventory.Items,
-			ItemDTO{Id: item, Quantity: quantity},
+			ItemDTO{Id: item, Quantity: quantity, IsEquipped: lo.Contains(equipped, item)},
 		)
 	}
 

--- a/backend/pkg/game/entities/inventory.go
+++ b/backend/pkg/game/entities/inventory.go
@@ -23,6 +23,7 @@ func (looter *Inventory) Loot(loot *Inventory) {
 	for item, qty := range loot.items {
 		looter.AddItem(item, qty)
 	}
+	loot.Clear()
 }
 
 func (looter *Inventory) AddItem(itemId string, quantity int64) {
@@ -68,6 +69,15 @@ func (inv *Inventory) PrintInventory() {
 			fmt.Printf("%s, %d - ", itemId, quantity)
 		}
 		fmt.Print("\n")
+	}
+}
+
+func (i *Inventory) Clear() {
+	for et := range i.equipped {
+		delete(i.equipped, et)
+	}
+	for k := range i.items {
+		delete(i.items, k)
 	}
 }
 

--- a/client/Assets/Scripts/GameManager.cs
+++ b/client/Assets/Scripts/GameManager.cs
@@ -187,11 +187,8 @@ public class GameManager : MonoBehaviour
     {
         foreach (CharacterDTO playerDTO in playerDTOS)
         {
-            if (playerDTO.inventory?.items == null)
-                return;
-
-            if (playerDTO.inventory?.items.Length == 0)
-                return;
+            if (playerDTO.inventory?.items == null || playerDTO.inventory?.items.Length == 0)
+                continue;
 
             Character player = GetPlayer(playerDTO.id);
             player.UpdateEquipmentVisuals(playerDTO.inventory.items);


### PR DESCRIPTION
Closes #58
Closes #56

- Refactors the `getInventoryDiff` function for improved readability.
- Sends character equipment in initial gamestate message. This was problematic because when a new client connected, it never got the equipment of characters already present in the game.
- Fixes issue where new characters sometimes didn't show their equipment in the client of already connected players. This was because the function that handled the visual feedback for the equipment returned on empty inventories instead of continuing a for loop.
- Character's inventories get emptied when looted. This has been introduced to avoid duplicated items, since when a player kills another it loots it's items.