### PR TITLE
Fix movement stuttering when a player character is dead

### DIFF
--- a/backend/pkg/game/gameplay/game_loop.go
+++ b/backend/pkg/game/gameplay/game_loop.go
@@ -36,7 +36,7 @@ func updatePlayers(gs *entities.GameState, deltaTime float64) {
 	for _, player := range gs.Players() {
 		if !player.IsAlive() {
 			player.ClearActionsQueue()
-			return
+			continue
 		}
 
 		player.ExecuteNextAction(gs)


### PR DESCRIPTION
Closes #63 

- Replaced return statement with continue in player update function, this was causing some player updates to be completely skipped. When a player was dead, the update function would return early sometimes, depending on the order of the players in the backend, which is random because they're stored in a map.