### PR TITLE
Expire buff based on timers instead of counteracting with opposite buff

### DIFF
--- a/backend/abilities.json
+++ b/backend/abilities.json
@@ -149,26 +149,9 @@
         "mechanic_type": "buff_stat",
         "params": {
           "base_amount": 0,
+          "duration_ms": 0,
           "multiplier": 0.5,
-          "on_hit_mechanics": [
-            {
-              "mechanic_type": "delay",
-              "params": {
-                "delay_ms": 5000,
-                "execute_after_delay_mechanics": [
-                  {
-                    "mechanic_type": "buff_stat",
-                    "params": {
-                      "base_amount": 0,
-                      "multiplier": -0.3333333333333333,
-                      "target_stat": "damage",
-                      "targeting_strategy": "character_hit"
-                    }
-                  }
-                ]
-              }
-            }
-          ],
+          "on_hit_mechanics": [],
           "target_stat": "damage",
           "targeting_strategy": "character_hit"
         }

--- a/backend/abilities.json
+++ b/backend/abilities.json
@@ -149,9 +149,8 @@
         "mechanic_type": "buff_stat",
         "params": {
           "base_amount": 0,
-          "duration_ms": 0,
+          "duration_ms": 5000,
           "multiplier": 0.5,
-          "on_hit_mechanics": [],
           "target_stat": "damage",
           "targeting_strategy": "character_hit"
         }

--- a/backend/pkg/configurator/ability_seeds.go
+++ b/backend/pkg/configurator/ability_seeds.go
@@ -148,25 +148,7 @@ func GetSeedsAbilities() map[string]*entities.Ability {
 					"base_amount":        0,
 					"multiplier":         0.5, // this is original value + (this * original value)
 					"targeting_strategy": "character_hit",
-					"on_hit_mechanics": []entities.Mechanic{
-						{
-							MechanicType: "delay",
-							Params: map[string]interface{}{
-								"delay_ms": 5000,
-								"execute_after_delay_mechanics": []entities.Mechanic{
-									{
-										MechanicType: "buff_stat",
-										Params: map[string]interface{}{
-											"target_stat":        "damage",
-											"base_amount":        0,
-											"multiplier":         -(1 / float64(3)), // this is original value + (this * original value)
-											"targeting_strategy": "character_hit",
-										},
-									},
-								},
-							},
-						},
-					},
+					"duration_ms":        5000,
 				},
 			},
 		),

--- a/backend/pkg/game/entities/character.go
+++ b/backend/pkg/game/entities/character.go
@@ -55,11 +55,12 @@ type CharacterLastTickState struct {
 
 // StatModification represents a modification to a character's stats
 type StatModification struct {
-	ID           string  // Unique identifier for the modification
-	StatName     string  // The stat being modified
-	FlatValue    int64   // Flat amount to add/subtract
-	PercentValue float64 // Percentage multiplier (e.g., 0.5 = +50%)
-	Source       string  // Source of the modification (e.g., "equipment", "ability_buff")
+	ID           string     // Unique identifier for the modification
+	StatName     string     // The stat being modified
+	FlatValue    int64      // Flat amount to add/subtract
+	PercentValue float64    // Percentage multiplier (e.g., 0.5 = +50%)
+	Source       string     // Source of the modification (e.g., "equipment", "ability_buff")
+	ExpiresAt    *time.Time // When the modification expires (nil means permanent)
 }
 
 type Character struct {
@@ -187,6 +188,26 @@ func (c *Character) RemoveStatModificationsBySource(source string) {
 	c.recalculateStats()
 }
 
+// RemoveExpiredBuffs removes all stat modifications that have expired
+func (c *Character) RemoveExpiredBuffs() {
+	now := time.Now()
+	newMods := []StatModification{}
+	removed := false
+
+	for _, mod := range c.statModifications {
+		if mod.ExpiresAt != nil && mod.ExpiresAt.Before(now) {
+			removed = true
+		} else {
+			newMods = append(newMods, mod)
+		}
+	}
+
+	if removed {
+		c.statModifications = newMods
+		c.recalculateStats()
+	}
+}
+
 // EquipItem equips an item and applies its stat modifications
 func (c *Character) EquipItem(itemId string) error {
 	// Get the item to be equipped to check its equipment type
@@ -230,6 +251,7 @@ func (c *Character) EquipItem(itemId string) error {
 					FlatValue:    value,
 					PercentValue: 0,
 					Source:       "equipment",
+					ExpiresAt:    nil, // Equipment stats are permanent
 				}
 				c.AddStatModification(mod)
 			}

--- a/backend/pkg/game/entities/character.go
+++ b/backend/pkg/game/entities/character.go
@@ -176,18 +176,6 @@ func (c *Character) RemoveStatModification(id string) {
 	}
 }
 
-// RemoveStatModificationsBySource removes all stat modifications from a specific source
-func (c *Character) RemoveStatModificationsBySource(source string) {
-	newMods := []StatModification{}
-	for _, mod := range c.statModifications {
-		if mod.Source != source {
-			newMods = append(newMods, mod)
-		}
-	}
-	c.statModifications = newMods
-	c.recalculateStats()
-}
-
 // RemoveExpiredBuffs removes all stat modifications that have expired
 func (c *Character) RemoveExpiredBuffs() {
 	now := time.Now()

--- a/backend/pkg/game/entities/mechanics.go
+++ b/backend/pkg/game/entities/mechanics.go
@@ -237,15 +237,29 @@ func BuffStatMechanic(caster *Character, gs *GameState, params map[string]interf
 		return nil
 	}
 
+	// Get duration in milliseconds
+	durationMs, ok := params["duration_ms"].(float64)
+	if !ok {
+		fmt.Println("Warning: 'duration_ms' not provided for temporary buff. Buff will be permanent.")
+		durationMs = 0
+	}
+
 	// Generate a unique ID for this modification
-	modID := fmt.Sprintf("ability_buff_%s_%s_%d", caster.id, statName, time.Now().UnixNano())
+	modID := fmt.Sprintf("buff_%s_%s_%d", caster.id, statName, time.Now().UnixNano())
+
+	var expiresAt *time.Time
+	if durationMs > 0 {
+		expirationTime := time.Now().Add(time.Duration(durationMs) * time.Millisecond)
+		expiresAt = &expirationTime
+	}
 
 	mod := StatModification{
 		ID:           modID,
 		StatName:     statName,
 		FlatValue:    flatValue,
 		PercentValue: percentValue,
-		Source:       "ability_buff",
+		Source:       "buff",
+		ExpiresAt:    expiresAt,
 	}
 
 	target.AddStatModification(mod)

--- a/backend/pkg/game/gameplay/game_loop.go
+++ b/backend/pkg/game/gameplay/game_loop.go
@@ -39,6 +39,9 @@ func updatePlayers(gs *entities.GameState, deltaTime float64) {
 			continue
 		}
 
+		// Remove expired buffs before processing actions
+		player.RemoveExpiredBuffs()
+
 		player.ExecuteNextAction(gs)
 		if player.IsMoving() {
 			if !player.UpdatePosition(deltaTime, gs.GetObstacleColliders()) {
@@ -96,6 +99,9 @@ func updateNpcs(gs *entities.GameState, deltaTime float64) {
 
 	for id, npc := range gs.NPCs() {
 		if npc.IsAlive() {
+			// Remove expired buffs before processing actions
+			npc.RemoveExpiredBuffs()
+
 			npc.ExecuteNextAction(gs)
 			npc.UpdateBehaviour()
 			if npc.IsMoving() {

--- a/backend/test/integration_test/integration_test.go
+++ b/backend/test/integration_test/integration_test.go
@@ -2,9 +2,11 @@ package integration_test
 
 import (
 	"backend/pkg/server"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/websocket"
@@ -74,6 +77,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// Wait until the configurator server is ready
+	if err := waitForPort("localhost:8080", 10*time.Second); err != nil {
+		fmt.Println("Configurator server failed to start:", err)
+		tearDownDocker(tempDir)
+		os.Exit(1)
+	}
+
 	// Run tests
 	code := m.Run()
 
@@ -106,6 +116,7 @@ type ServerTestSuite struct {
 	suite.Suite
 	paladin   *TestClient
 	barbarian *TestClient
+	test      *TestClient
 }
 
 func (suite *ServerTestSuite) SetupSuite() {
@@ -116,6 +127,7 @@ func (suite *ServerTestSuite) SetupSuite() {
 func (suite *ServerTestSuite) TearDownSuite() {
 	suite.paladin.Close()
 	suite.barbarian.Close()
+	// close test conn
 }
 
 // ----------------------
@@ -126,6 +138,7 @@ func (suite *ServerTestSuite) Test_FullGameplayFlow() {
 	suite.Run("DuplicateConnection", suite.testDuplicateCharacterConnection)
 	suite.Run("Projectiles", suite.testProjectileDamagesTarget)
 	suite.Run("PersistenceAfterReconnect", suite.testPersistenceAfterReconnect)
+	suite.Run("ChangePlayersInitialAbilities", suite.testChangePlayersInitialAbilities)
 }
 
 func TestIntegrationSuite(t *testing.T) {
@@ -221,6 +234,53 @@ func (suite *ServerTestSuite) testPersistenceAfterReconnect() {
 			}
 		}
 	}
+}
+
+func (suite *ServerTestSuite) testChangePlayersInitialAbilities() {
+	// avoid having to disconnect already connected characters because they interfere with the assert
+	suite.barbarian.Close()
+	suite.paladin.Close()
+
+	playersInitialAbilitiesIds := [4]string{"1", "2", "3", "5"}
+	jsonPayload, _ := json.Marshal(playersInitialAbilitiesIds)
+	resp, err := http.Post("http://0.0.0.0:8080/playersInitialAbilities", "application/json", bytes.NewBuffer(jsonPayload))
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	suite.test = connectClient("test")
+
+	_, err = suite.test.WaitForGameStateDiff(3*time.Second, func(body map[string]interface{}) bool {
+		players, ok := body["players"].([]interface{})
+		if !ok {
+			return false
+		}
+
+		// Look for a character that has ability "5" (Buff Damage) which should be the new character
+		return lo.ContainsBy(players, func(player interface{}) bool {
+			return characterHasAbility(player, "5")
+		})
+	})
+	suite.Require().NoError(err, "Should find a character with ability '5' (Buff Damage) after changing initial abilities")
+}
+
+// ----------------------
+// Helper functions
+// ----------------------
+
+func characterHasAbility(c interface{}, abilityID string) bool {
+	pm := c.(map[string]interface{})
+	abilities, ok := pm["abilities"].([]interface{})
+	if !ok {
+		return false
+	}
+	return lo.ContainsBy(abilities, func(ability interface{}) bool {
+		abilityMap, ok := ability.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		id, ok := abilityMap["id"].(string)
+		return ok && id == abilityID
+	})
 }
 
 // ----------------------

--- a/backend/test/integration_test/integration_test.go
+++ b/backend/test/integration_test/integration_test.go
@@ -139,6 +139,7 @@ func (suite *ServerTestSuite) Test_FullGameplayFlow() {
 	suite.Run("Projectiles", suite.testProjectileDamagesTarget)
 	suite.Run("PersistenceAfterReconnect", suite.testPersistenceAfterReconnect)
 	suite.Run("ChangePlayersInitialAbilities", suite.testChangePlayersInitialAbilities)
+	suite.Run("BuffDamageTarget", suite.testBuffDamageTarget)
 }
 
 func TestIntegrationSuite(t *testing.T) {
@@ -263,6 +264,110 @@ func (suite *ServerTestSuite) testChangePlayersInitialAbilities() {
 	suite.Require().NoError(err, "Should find a character with ability '5' (Buff Damage) after changing initial abilities")
 }
 
+func (suite *ServerTestSuite) testBuffDamageTarget() {
+	// Wait for the test character to be fully connected and get initial stats
+	initialStats, err := suite.test.WaitForGameStateDiff(3*time.Second, func(body map[string]interface{}) bool {
+		players, ok := body["players"].([]interface{})
+		if !ok {
+			return false
+		}
+		return lo.ContainsBy(players, func(player interface{}) bool {
+			pm := player.(map[string]interface{})
+			if id, ok := pm["id"].(string); ok && id == suite.test.CharacterID {
+				// Check if stats are present (means character is fully loaded)
+				_, hasStats := pm["stats"]
+				return hasStats
+			}
+			return false
+		})
+	})
+	suite.Require().NoError(err, "Should receive initial character stats")
+
+	// Extract initial damage stat
+	var initialDamage int64
+	players := initialStats["players"].([]interface{})
+	for _, p := range players {
+		pm := p.(map[string]interface{})
+		if id, ok := pm["id"].(string); ok && id == suite.test.CharacterID {
+			if stats, ok := pm["stats"].(map[string]interface{}); ok {
+				if damage, ok := stats["damage"].(float64); ok {
+					initialDamage = int64(damage)
+					break
+				}
+			}
+		}
+	}
+	suite.Require().True(initialDamage > 0, "Should have initial damage stat")
+
+	// Test character casts buff on itself
+	err = suite.test.Send("ability_cast", map[string]interface{}{
+		"id": "5",
+		"abilityParameters": map[string]interface{}{
+			"TargetId": suite.test.CharacterID,
+		},
+	})
+	suite.Require().NoError(err)
+
+	// Wait for buff to be applied and verify damage stat increased
+	buffedStats, err := suite.test.WaitForGameStateDiff(3*time.Second, func(body map[string]interface{}) bool {
+		players, ok := body["players"].([]interface{})
+		if !ok {
+			return false
+		}
+		return lo.ContainsBy(players, func(player interface{}) bool {
+			pm := player.(map[string]interface{})
+			if id, ok := pm["id"].(string); ok && id == suite.test.CharacterID {
+				if stats, ok := pm["stats"].(map[string]interface{}); ok {
+					_, hasDamageStat := stats["damage"]
+					return hasDamageStat
+				}
+			}
+			return false
+		})
+	})
+	suite.Require().NoError(err, "Should receive buffed character stats")
+
+	// Verify the damage stat is higher
+	var buffedDamage int64
+	players = buffedStats["players"].([]interface{})
+	for _, p := range players {
+		pm := p.(map[string]interface{})
+		if id, ok := pm["id"].(string); ok && id == suite.test.CharacterID {
+			if stats, ok := pm["stats"].(map[string]interface{}); ok {
+				if damage, ok := stats["damage"].(float64); ok {
+					buffedDamage = int64(damage)
+					break
+				}
+			}
+		}
+	}
+	suite.True(buffedDamage > initialDamage, fmt.Sprintf("Damage should be higher after buff, original value: %d, new value: %d", initialDamage, buffedDamage))
+
+	// Wait for buff to expire (buff duration is 5000ms = 5 seconds)
+	time.Sleep(6 * time.Second)
+
+	// Wait for buff to expire and verify damage stat returned to original
+	_, err = suite.test.WaitForGameStateDiff(3*time.Second, func(body map[string]interface{}) bool {
+		players, ok := body["players"].([]interface{})
+		if !ok {
+			return false
+		}
+		return lo.ContainsBy(players, func(player interface{}) bool {
+			pm := player.(map[string]interface{})
+			if id, ok := pm["id"].(string); ok && id == suite.test.CharacterID {
+				if stats, ok := pm["stats"].(map[string]interface{}); ok {
+					if damage, ok := stats["damage"].(float64); ok {
+						// Check if damage is back to initial value
+						return int64(damage) == initialDamage
+					}
+				}
+			}
+			return false
+		})
+	})
+	suite.Require().NoError(err, "Damage should return to original value after buff expires")
+}
+
 // ----------------------
 // Helper functions
 // ----------------------
@@ -306,8 +411,9 @@ type WSMessage struct {
 }
 
 type TestClient struct {
-	Conn    *websocket.Conn
-	MsgChan chan WSMessage
+	Conn        *websocket.Conn
+	MsgChan     chan WSMessage
+	CharacterID string
 }
 
 func connectClient(characterID string) *TestClient {
@@ -318,8 +424,9 @@ func connectClient(characterID string) *TestClient {
 	}
 
 	client := &TestClient{
-		Conn:    conn,
-		MsgChan: make(chan WSMessage, 10),
+		Conn:        conn,
+		MsgChan:     make(chan WSMessage, 10),
+		CharacterID: "", // Will be set from first Player message
 	}
 
 	// Reader goroutine
@@ -333,6 +440,12 @@ func connectClient(characterID string) *TestClient {
 			}
 			var msg WSMessage
 			if err := json.Unmarshal(buf[:n], &msg); err == nil {
+				// Capture character ID from first Player message
+				if msg.ActionType == "Player" && client.CharacterID == "" {
+					if id, ok := msg.Body["id"].(string); ok {
+						client.CharacterID = id
+					}
+				}
 				client.MsgChan <- msg
 			}
 		}

--- a/client/Assets/Editor/Scripts/AbilitiesEditorWindow.cs
+++ b/client/Assets/Editor/Scripts/AbilitiesEditorWindow.cs
@@ -756,6 +756,8 @@ public class AbilityMechanicManager
         int newTargetingStrategySelectedIndex = EditorGUILayout.Popup("Targeting Strategy", targetingStrategySelectedIndex, TargetingStrategies);
         buffStatParams.targetingStrategy = TargetingStrategies[newTargetingStrategySelectedIndex];
 
+        buffStatParams.durationMs = EditorGUILayout.IntField("Duration (ms)", buffStatParams.durationMs);
+
         GUILayout.Label("On Hit Mechanics:", EditorStyles.boldLabel);
         buffStatParams.onHitMechanics = DisplayMechanics(buffStatParams.onHitMechanics, true);
         mechanic.@params = buffStatParams;

--- a/client/Assets/Editor/Scripts/Dtos/AbilityDTO.cs
+++ b/client/Assets/Editor/Scripts/Dtos/AbilityDTO.cs
@@ -193,6 +193,7 @@ namespace Configurator
             [JsonProperty("base_amount")] public int baseAmount;
             [JsonProperty("multiplier")] public float multiplier;
             [JsonProperty("targeting_strategy")] public string targetingStrategy;
+            [JsonProperty("duration_ms")] public int durationMs;
             [JsonProperty("on_hit_mechanics")] public List<MechanicDTO> onHitMechanics;
 
             public BuffStatParams()
@@ -201,6 +202,7 @@ namespace Configurator
                 baseAmount = 0;
                 multiplier = 0;
                 targetingStrategy = "TO DO";
+                durationMs = 1000;
                 onHitMechanics = new List<MechanicDTO>();
             }
 
@@ -217,6 +219,7 @@ namespace Configurator
                     baseAmount = this.baseAmount,
                     multiplier = this.multiplier,
                     targetingStrategy = this.targetingStrategy,
+                    durationMs = this.durationMs,
                     onHitMechanics = onHitMechanicsCopy
                 };
             }


### PR DESCRIPTION
Closes #52 

Changes the way temporary buffs expire. Before, when the time was up, an opposite buff that cancelled out the original effect would apply. Now a timer is implemented to remove the buff and recalculate the stats.

This PR also introduces two tests, one to check that changing player's initial abilities works and one that checks that a buff damage ability works. The second one made sense to add here since the PR is modifying buffs, and the first one was required by the second one since the buff damage ability isn't in the initial player's abilities, and since tests are run sequentially and their effects endure to the next tests, adding it meant the required ability was available for the buff test.