### PR TITLE
Fix WebSocket connection delay in WSL2 (IPv6 localhost)

### DIFF
--- a/client/Assets/Scripts/AuthenticationManager.cs
+++ b/client/Assets/Scripts/AuthenticationManager.cs
@@ -55,7 +55,7 @@ public class AuthenticationManager : MonoBehaviour
 
 public class CharactersHttpClient
 {
-    const string BACKEND_URL = "http://0.0.0.0:8081";
+    const string BACKEND_URL = "http://127.0.0.1:8081";
 
     public async Task<CharacterDTO[]> GetCharacters()
     {

--- a/client/Assets/Scripts/Services/WebSocketConnection.cs
+++ b/client/Assets/Scripts/Services/WebSocketConnection.cs
@@ -11,7 +11,7 @@ using UnityEditor;
 public static class WebSocketConnection
 {
     static ClientWebSocket webSocket;
-    static String URL = "ws://localhost:3009/ws";
+    static String URL = "ws://127.0.0.1:3009/ws";
     static Dictionary<string, Delegate> _responseHandlers = new Dictionary<string, Delegate>();
     public static bool IsConnected { get { return webSocket.State == WebSocketState.Open; } }
 
@@ -113,7 +113,7 @@ public static class WebSocketConnection
             }
             else
             {
-                Debug.LogError("Message from server is not text");
+                Debug.LogError("Message from server is not binary");
             }
         }
     }


### PR DESCRIPTION
Enforce websockets on client try to connect directly to IPv4 instead of trying to IPv6 first. This caused an issue when running the client on windows and trying to connect to a backend running in WSL2 where there would be a 10 or 15 delay when trying to establish the ws connection.