### PR TITLE
Migrate WebSocket server from x/net/websocket to gorilla/websocket

### DIFF
--- a/backend/connection/native_server.go
+++ b/backend/connection/native_server.go
@@ -14,45 +14,83 @@ import (
 	"backend/pkg/game/gameplay"
 	"backend/pkg/utils"
 
+	"github.com/gorilla/websocket"
 	"github.com/samber/lo"
-	"golang.org/x/net/websocket"
 )
+
+// connWriter serializes writes to a single WebSocket connection.
+// gorilla/websocket connections do not support concurrent writes;
+// this type ensures all sends go through a single dedicated goroutine.
+type connWriter struct {
+	ch chan []byte
+}
+
+func newConnWriter(conn *websocket.Conn) *connWriter {
+	cw := &connWriter{ch: make(chan []byte, 256)}
+	go func() {
+		for msg := range cw.ch {
+			if err := conn.WriteMessage(websocket.BinaryMessage, msg); err != nil {
+				return
+			}
+		}
+	}()
+	return cw
+}
+
+func (cw *connWriter) send(data []byte) {
+	select {
+	case cw.ch <- data:
+	default:
+		log.Println("Warning: send buffer full, dropping message")
+	}
+}
+
+type addClientReply struct {
+	err    error
+	writer *connWriter
+}
 
 type AddClientData struct {
 	Client    *websocket.Conn
 	Character string
-	Reply     chan error
+	Reply     chan addClientReply
 }
 
 type NativeServer struct {
-	clients             map[*websocket.Conn]bool
+	clients             map[*websocket.Conn]*connWriter
 	connectedCharacters map[*websocket.Conn]string
 	addClient           chan AddClientData
 	removeClient        chan *websocket.Conn
 	tick                chan float64
 	gameState           *entities.GameState
+	upgrader            websocket.Upgrader
 }
 
 func NewServer() *NativeServer {
 	gamestate := gameplay.StartGameState()
 
 	return &NativeServer{
-		clients:             make(map[*websocket.Conn]bool),
+		clients:             make(map[*websocket.Conn]*connWriter),
 		connectedCharacters: make(map[*websocket.Conn]string),
 		addClient:           make(chan AddClientData),
 		removeClient:        make(chan *websocket.Conn),
 		tick:                make(chan float64),
 		gameState:           gamestate,
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
 	}
 }
 
 func (ws NativeServer) StartConnection(port string) {
-	http.Handle("/ws", websocket.Handler(ws.handleWebSocket))
+	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		ws.handleWebSocket(w, r)
+	})
 	go ws.gameLoop()
 	go ws.tickLoop()
 
-	log.Println("WebSocket server running on :" + port)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	log.Println("WebSocket server running on 127.0.0.1:" + port)
+	log.Fatal(http.ListenAndServe("127.0.0.1:"+port, nil))
 }
 
 func (server *NativeServer) gameLoop() {
@@ -61,38 +99,37 @@ func (server *NativeServer) gameLoop() {
 		case clientData := <-server.addClient:
 			if lo.Contains(lo.Values(server.connectedCharacters), clientData.Character) {
 				log.Println("Error, character already in use")
-				clientData.Reply <- errors.New("character already in use")
+				clientData.Reply <- addClientReply{err: errors.New("character already in use")}
 				continue
 			}
 			player := gameplay.AddPlayer(server.gameState, clientData.Client, clientData.Character)
 			server.connectedCharacters[clientData.Client] = clientData.Character
-			clientData.Reply <- nil
+
+			writer := newConnWriter(clientData.Client)
+
+			response := CreateWebSocketResponse(dtos.CharacterToDTO(player))
+			writer.send(response.Serialize())
+
+			// Send initial game state to new client
+			gameStateDTO := dtos.GameStateToDTO(*server.gameState)
+			webSocketResponse := CreateWebSocketResponse(gameStateDTO)
+			writer.send(webSocketResponse.Serialize())
+
+			// Add to broadcast set only after initial messages are queued so the
+			// client receives them in order before any tick updates.
+			server.clients[clientData.Client] = writer
+			clientData.Reply <- addClientReply{writer: writer}
 			log.Println("Client connected", clientData.Client.RemoteAddr())
 
-			go func() {
-				response := CreateWebSocketResponse(dtos.CharacterToDTO(player))
-				message := response.Serialize()
-				err := websocket.Message.Send(clientData.Client, message)
-				if err != nil {
-					log.Println("Error broadcasting character message:", err)
-					return
-				}
-
-				// Send initial gamestate to client
-				gameStateDTO := dtos.GameStateToDTO(*server.gameState)
-				webSocketResponse := CreateWebSocketResponse(gameStateDTO)
-				if err := websocket.Message.Send(clientData.Client, webSocketResponse.Serialize()); err != nil {
-					log.Println("Error broadcasting initial message:", err)
-					return
-				}
-
-				server.clients[clientData.Client] = true
-			}()
 		case client := <-server.removeClient:
-			delete(server.clients, client)
+			if writer, ok := server.clients[client]; ok {
+				close(writer.ch)
+				delete(server.clients, client)
+			}
 			delete(server.connectedCharacters, client)
 			server.gameState.DeletePlayer(client)
 			log.Println("Client disconnected", client.RemoteAddr())
+
 		case deltaTime := <-server.tick:
 			gameplay.UpdateState(server.gameState, deltaTime)
 
@@ -100,19 +137,13 @@ func (server *NativeServer) gameLoop() {
 			webSocketResponse := CreateWebSocketResponse(gameStateDTO)
 			message := webSocketResponse.Serialize()
 
-			for client := range server.clients {
-				err := websocket.Message.Send(client, message)
-				if err != nil {
-					log.Println("Error broadcasting tick message:", err)
-					return
-				}
+			for _, writer := range server.clients {
+				writer.send(message)
 			}
 		}
 	}
 }
 
-// the broadcast function should just broadcast, the updating of the state should be handled somewhere else
-// actually, native server shouldn't know anything about game state, it should only receive messages that it should send to the clients, but how then would client that connect to the server be convereted to players?
 func (server *NativeServer) tickLoop() {
 	ticker := time.NewTicker(config.TICKER_TIME)
 	defer ticker.Stop()
@@ -126,30 +157,39 @@ func (server *NativeServer) tickLoop() {
 	}
 }
 
-func (server *NativeServer) handleWebSocket(conn *websocket.Conn) {
-	// Get query parameter "character"
-	character := conn.Request().URL.Query().Get("character")
+func (server *NativeServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	character := r.URL.Query().Get("character")
 
-	reply := make(chan error)
-	server.addClient <- AddClientData{conn, character, reply}
+	conn, err := server.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("Error upgrading connection:", err)
+		return
+	}
 
-	if <-reply != nil {
+	reply := make(chan addClientReply)
+	server.addClient <- AddClientData{Client: conn, Character: character, Reply: reply}
+
+	result := <-reply
+	if result.err != nil {
 		errMsg := map[string]string{"error": "character already in use"}
 		data, _ := json.Marshal(errMsg)
-		conn.Write(data)
+		if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+			log.Println("Error sending rejection message:", err)
+		}
 		conn.Close()
 		return
 	}
+
+	writer := result.writer
 
 	defer func() {
 		conn.Close()
 		server.removeClient <- conn
 	}()
 	for {
-		var data []byte
-		err := websocket.Message.Receive(conn, &data)
+		_, data, err := conn.ReadMessage()
 		if err != nil {
-			log.Println("Error reading message from client: ", err, &conn)
+			log.Println("Error reading message from client: ", err, conn.RemoteAddr())
 			break
 		}
 
@@ -165,7 +205,7 @@ func (server *NativeServer) handleWebSocket(conn *websocket.Conn) {
 		case "ability_cast":
 			server.handleAbilityCast(conn, message.Body.(dtos.AbilityCastDTO))
 		case "respawn":
-			server.handleRespawn(conn)
+			server.handleRespawn(conn, writer)
 		case "use_item":
 			server.handleUseItem(conn, message.Body.(dtos.UseItemDTO))
 		case "equip_item":
@@ -228,7 +268,7 @@ func (server *NativeServer) handleAbilityCast(
 	player.EnqueueAbilityCastAction(abilityCastDTO.Id, castParameters)
 }
 
-func (server *NativeServer) handleRespawn(client *websocket.Conn) {
+func (server *NativeServer) handleRespawn(client *websocket.Conn, writer *connWriter) {
 	player := server.gameState.GetPlayerByConn(client)
 	if !player.IsAlive() {
 		player.HealthVariation(player.GetMaxHealth())
@@ -236,8 +276,7 @@ func (server *NativeServer) handleRespawn(client *websocket.Conn) {
 		player.SetPosition(*utils.NewVector2(0, 0))
 		response := CreateWebSocketResponse(dtos.CharacterToDTO(*player))
 		response.ActionType = "respawn"
-		message := response.Serialize()
-		websocket.Message.Send(client, message)
+		writer.send(response.Serialize())
 	}
 }
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,11 +4,12 @@ go 1.24.0
 
 toolchain go1.24.4
 
-require golang.org/x/net v0.43.0
+require golang.org/x/net v0.43.0 // indirect
 
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.11.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -30,6 +30,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/pkg/game/entities/game_state.go
+++ b/backend/pkg/game/entities/game_state.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/net/websocket"
+	"github.com/gorilla/websocket"
 
 	"backend/pkg/utils"
 )

--- a/backend/pkg/game/gameplay/game_loop.go
+++ b/backend/pkg/game/gameplay/game_loop.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/net/websocket"
+	"github.com/gorilla/websocket"
 )
 
 func StartGameState() *entities.GameState {

--- a/backend/test/integration_test/integration_test.go
+++ b/backend/test/integration_test/integration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/websocket"
+	"github.com/gorilla/websocket"
 )
 
 // ----------------------
@@ -149,15 +149,14 @@ func TestIntegrationSuite(t *testing.T) {
 func (suite *ServerTestSuite) testDuplicateCharacterConnection() {
 	url := "ws://localhost:3009/ws?character=barbarian"
 
-	conn2, err := websocket.Dial(url, "", "http://localhost/")
+	conn2, _, err := websocket.DefaultDialer.Dial(url, nil)
 	assert.NoError(suite.T(), err, "second client should connect initially")
 	defer conn2.Close()
 
-	buf := make([]byte, 512)
-	n, err := conn2.Read(buf)
+	_, data, err := conn2.ReadMessage()
 	assert.NoError(suite.T(), err, "should read close/error message")
 
-	assert.Contains(suite.T(), string(buf[:n]), "character already in use")
+	assert.Contains(suite.T(), string(data), "character already in use")
 }
 
 func (suite *ServerTestSuite) testProjectileDamagesTarget() {
@@ -418,7 +417,7 @@ type TestClient struct {
 
 func connectClient(characterID string) *TestClient {
 	url := fmt.Sprintf("ws://localhost:3009/ws?character=%s", characterID)
-	conn, err := websocket.Dial(url, "", "http://localhost/")
+	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
 	if err != nil {
 		panic(fmt.Sprintf("failed to connect %s: %v", characterID, err))
 	}
@@ -432,14 +431,13 @@ func connectClient(characterID string) *TestClient {
 	// Reader goroutine
 	go func() {
 		defer close(client.MsgChan)
-		buf := make([]byte, 8192)
 		for {
-			n, err := conn.Read(buf)
+			_, buf, err := conn.ReadMessage()
 			if err != nil {
 				return
 			}
 			var msg WSMessage
-			if err := json.Unmarshal(buf[:n], &msg); err == nil {
+			if err := json.Unmarshal(buf, &msg); err == nil {
 				// Capture character ID from first Player message
 				if msg.ActionType == "Player" && client.CharacterID == "" {
 					if id, ok := msg.Body["id"].(string); ok {
@@ -460,8 +458,7 @@ func (c *TestClient) Send(actionType string, body any) error {
 		"body":       body,
 	}
 	data, _ := json.Marshal(msg)
-	_, err := c.Conn.Write(data)
-	return err
+	return c.Conn.WriteMessage(websocket.TextMessage, data)
 }
 
 func (c *TestClient) Close() { c.Conn.Close() }


### PR DESCRIPTION
Replace golang.org/x/net/websocket with github.com/gorilla/websocket across the backend. Key changes:

- Introduce connWriter (buffered channel + dedicated write goroutine) per connection to satisfy gorilla's no-concurrent-writes constraint
- Replace websocket.Handler with http.HandleFunc + upgrader.Upgrade
- Replace websocket.Message.Send/Receive with WriteMessage/ReadMessage
- Use BinaryMessage for server→client sends to match what the Unity client expects (it only handles Binary frames)
- Update integration test client (Dial, Read, Write calls)
- golang.org/x/net demoted to indirect in go.mod